### PR TITLE
python3Packages.box: init at 4.2.3

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -43,6 +43,7 @@ rec {
       propagatedBuildInputs = oldAttrs.propagatedBuildInputs ++ [ cirq ];
     });
     pubchempy = pkgs.python3.pkgs.callPackage ./pkgs/python-modules/pubchempy { };
+    python-box = pkgs.python3.pkgs.callPackage ./pkgs/python-modules/python-box { };
     openfermion = pkgs.python3.pkgs.callPackage ./pkgs/python-modules/openfermion { inherit pubchempy; };
     openfermion-cirq = pkgs.python3.pkgs.callPackage ./pkgs/python-modules/openfermion-cirq { inherit cirq openfermion; };
     setuptools-rust = pkgs.python3.pkgs.callPackage ./pkgs/python-modules/setuptools-rust { };

--- a/pkgs/python-modules/cirq/default.nix
+++ b/pkgs/python-modules/cirq/default.nix
@@ -92,6 +92,7 @@ buildPythonPackage rec {
     "--ignore=dev_tools"  # Only needed when developing new code, which is out-of-scope
     "-rfE"
     # "--durations=25"
+    "--benchmark-disable"
   ];
   # TODO: remove disables before aarch64 on NixOS 20.09+, working protobuf version.
   disabledTests = [

--- a/pkgs/python-modules/python-box/default.nix
+++ b/pkgs/python-modules/python-box/default.nix
@@ -1,0 +1,40 @@
+{ lib
+, buildPythonPackage
+, pythonOlder
+, fetchFromGitHub
+, msgpack
+, ruamel_yaml
+, toml
+  # test inputs
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "python-box";
+  version = "4.2.3";
+
+  disabled = pythonOlder "3.6";
+
+  src = fetchFromGitHub {
+    owner = "cdgriffith";
+    repo = "box";
+    rev = version;
+    sha256 = "1rqc5zbbdbz5fhxbrhh84bzw7lbkck0jnas0wqdnmkj7ya3810nb";
+  };
+
+  propagatedBuildInputs = [
+    ruamel_yaml
+    toml
+  ];
+
+  dontUseSetuptoolsCheck = true;
+  checkInputs = [ pytestCheckHook ];
+
+  meta = with lib; {
+    description = "Python dictionaries with advanced dot notation access";
+    homepage = "https://github.com/cdgriffith/Box/wiki";
+    changelog = "https://github.com/cdgriffith/Box/releases/tag/${version}";
+    license = licenses.mit;
+    maintainers = with maintainers; [ drewrisinger ];
+  };
+}


### PR DESCRIPTION
Utility to access dictionaries using dot-notation, which is just a little easier to read/use.

https://pypi.org/project/python-box/

Using this version b/c the tests fail with 5.1.1 & msgpack on Nixos 20.03. Can update later when Nixos 20.09 is released.

Also just disables Cirq benchmark tests b/c I'm feeling lazy & don't want to create another PR.