### PR TITLE
Qiskit: build packages without visualization tools

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -100,6 +100,7 @@ rec {
     qiskit = pkgs.python3.pkgs.callPackage ./pkgs/python-modules/qiskit {
       inherit qiskit-aer qiskit-terra qiskit-ignis qiskit-aqua qiskit-ibmq-provider;
     };
+    qiskit-terraNoVisual = qiskit-terra.override { withVisualization = false; };
   };
 
 }

--- a/default.nix
+++ b/default.nix
@@ -24,6 +24,7 @@ rec {
   libcint = pkgs.callPackage ./pkgs/libraries/libcint { };
   xcfun = pkgs.callPackage ./pkgs/libraries/xcfun { };
   muparserx = pkgs.callPackage ./pkgs/libraries/muparserx { };
+  tuna = pkgs.python3.pkgs.callPackage ./pkgs/python-modules/tuna { };
 
   python3Packages = pkgs.recurseIntoAttrs rec {
     # New packages NOT in NixOS/nixpkgs (and likely never will be)

--- a/default.nix
+++ b/default.nix
@@ -101,6 +101,7 @@ rec {
       inherit qiskit-aer qiskit-terra qiskit-ignis qiskit-aqua qiskit-ibmq-provider;
     };
     qiskit-terraNoVisual = qiskit-terra.override { withVisualization = false; };
+    qiskit-ibmq-providerNoVisual = qiskit-ibmq-provider.override { withVisualization = false; qiskit-terra = qiskit-terraNoVisual; matplotlib = null; };
   };
 
 }

--- a/pkgs/python-modules/qiskit-ibmq-provider/default.nix
+++ b/pkgs/python-modules/qiskit-ibmq-provider/default.nix
@@ -9,7 +9,8 @@
 , requests_ntlm
 , websockets
   # Visualization inputs
-, ipykernel
+, withVisualization ? true
+, ipython
 , ipyvuetify
 , ipywidgets
 , matplotlib
@@ -24,6 +25,19 @@
 , vcrpy
 }:
 
+let
+  visualizationPackages = [
+    ipython
+    ipyvuetify
+    ipywidgets
+    matplotlib
+    nbconvert
+    nbformat
+    plotly
+    pyperclip
+    seaborn
+  ];
+in
 buildPythonPackage rec {
   pname = "qiskit-ibmq-provider";
   version = "0.9.0";
@@ -44,30 +58,16 @@ buildPythonPackage rec {
     requests
     requests_ntlm
     websockets
-    # Visualization/Jupyter inputs
-    ipykernel
-    ipyvuetify
-    ipywidgets
-    matplotlib
-    nbconvert
-    nbformat
-    plotly
-    pyperclip
-    seaborn
-  ];
-
-  # websockets seems to be pinned b/c in v8+ it drops py3.5 support. Not an issue here (usually py3.7+, and disabled for older py3.6)
-  postPatch = ''
-    substituteInPlace requirements.txt --replace "websockets>=7,<8" "websockets"
-    substituteInPlace setup.py --replace "websockets>=7,<8" "websockets"
-  '';
+  ] ++ lib.optional withVisualization visualizationPackages;
 
   # Most tests require credentials to run on IBMQ
   checkInputs = [
     pytestCheckHook
+    nbconvert
+    nbformat
     pproxy
     vcrpy
-  ];
+  ] ++ visualizationPackages;
   dontUseSetuptoolsCheck = true;
 
   pythonImportsCheck = [ "qiskit.providers.ibmq" ];

--- a/pkgs/python-modules/qiskit-terra/default.nix
+++ b/pkgs/python-modules/qiskit-terra/default.nix
@@ -16,6 +16,7 @@
 , retworkx
 , scipy
 , sympy
+, withVisualization ? true
   # Python visualization requirements, semi-optional
 , ipywidgets
 , matplotlib
@@ -24,6 +25,9 @@
 , pygments
 , pylatexenc
 , seaborn
+  # Crosstalk-adaptive layout pass
+, withCrosstalkPass ? false
+, z3
   # test requirements
 , ddt
 , hypothesis
@@ -32,6 +36,19 @@
 , pytestCheckHook
 , python
 }:
+
+let
+  visualizationPackages = [
+    ipywidgets
+    matplotlib
+    pillow
+    pydot
+    pygments
+    pylatexenc
+    seaborn
+  ];
+  crosstalkPackages = [ z3 ];
+in
 
 buildPythonPackage rec {
   pname = "qiskit-terra";
@@ -53,7 +70,6 @@ buildPythonPackage rec {
     fastjsonschema
     jsonschema
     numpy
-    matplotlib
     networkx
     ply
     psutil
@@ -62,25 +78,18 @@ buildPythonPackage rec {
     retworkx
     scipy
     sympy
-    # Optional/visualization inputs
-    ipywidgets
-    matplotlib
-    pillow
-    pydot
-    pygments
-    pylatexenc
-    seaborn
-  ];
+  ] ++ lib.optional withVisualization visualizationPackages
+  ++ lib.optional withCrosstalkPass crosstalkPackages;
 
 
   # *** Tests ***
   checkInputs = [
+    pytestCheckHook
     ddt
     hypothesis
     nbformat
     nbconvert
-    pytestCheckHook
-  ];
+  ] ++ visualizationPackages;
   dontUseSetuptoolsCheck = true;  # can't find setup.py, so fails. tested by pytest
 
   pythonImportsCheck = [

--- a/pkgs/python-modules/tuna/default.nix
+++ b/pkgs/python-modules/tuna/default.nix
@@ -1,0 +1,33 @@
+{ lib
+, buildPythonApplication
+, pythonOlder
+, fetchPypi
+  # test inputs
+, pytestCheckHook
+}:
+
+buildPythonApplication rec {
+  pname = "tuna";
+  version = "0.4.7";
+  format = "pyproject";
+
+  disabled = pythonOlder "3.6";
+
+  # Use PyPi b/c some Javascript files aren't included in GitHub checkout
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "7a4eb545bde7eb5cd43a7d1233e55c15bfe3101a0fff3da5cde1ff68b2191bcb";
+  };
+
+  dontUseSetuptoolsCheck = true;
+  checkInputs = [ pytestCheckHook ];
+  preCheck = "export PATH=$out/bin:$PATH";
+
+  meta = with lib; {
+    description = "Python profile viewer";
+    homepage = "https://github.com/nschloe/tuna";
+    changelog = "https://github.com/nschloe/tuna/releases/tag/v${version}";
+    license = licenses.gpl3;   # gpl3Only
+    maintainers = with maintainers; [ drewrisinger ];
+  };
+}


### PR DESCRIPTION
Allows creating pure/low-dependency qiskit packages that import faster b/c they're missing bigger packages like ``matplotlib, ipython``.

Adds ``tuna`` to help in visualizing import time profiling.