### PR TITLE
python3Packages.cirq: add copy at version 0.5.0

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -55,6 +55,8 @@ rec {
 
     # More recent version than in Nixpkgs
     cirq = pkgs.python3.pkgs.callPackage ./pkgs/python-modules/cirq { };
+    # temporary cirq package, meant for transition from python3.5 -> py3.7 (Nix)
+    cirq_0_5 = pkgs.python3.pkgs.callPackage ./pkgs/python-modules/cirq/0.5.nix { };
     cvxpy = pkgs.python3.pkgs.callPackage ./pkgs/python-modules/cvxpy { inherit ecos osqp scs; };
     ecos = pkgs.python3.pkgs.callPackage ./pkgs/python-modules/ecos { };
     osqp = pkgs.python3.pkgs.callPackage ./pkgs/python-modules/osqp { };

--- a/pkgs/python-modules/cirq/0.5.nix
+++ b/pkgs/python-modules/cirq/0.5.nix
@@ -1,0 +1,122 @@
+{ stdenv
+, lib
+, buildPythonPackage
+, pythonOlder
+, fetchFromGitHub
+, fetchpatch
+, freezegun
+, google_api_python_client
+, matplotlib
+, networkx
+, numpy
+, pandas
+, protobuf
+, requests
+, scipy
+, sortedcontainers
+, sympy
+, typing-extensions
+  # test inputs
+, pytestCheckHook
+, pytest-benchmark
+, ply
+, pydot
+, pyyaml
+, pygraphviz
+}:
+
+buildPythonPackage rec {
+  pname = "cirq";
+  version = "0.5.0";
+
+  disabled = pythonOlder "3.5";
+
+  src = fetchFromGitHub {
+    owner = "quantumlib";
+    repo = "cirq";
+    rev = "v${version}";
+    sha256 = "1wnj65cjs6r3k6zb5287gsk2df1zvcy1fc9hmnhi6hnzwmwzpphp";
+  };
+
+  postPatch = ''
+    substituteInPlace requirements.txt \
+      --replace "matplotlib~=2.2" "matplotlib" \
+      --replace "networkx~=2.1" "networkx" \
+      --replace "numpy~=1.12" "numpy" \
+      --replace "protobuf~=3.5.0" "protobuf"
+  '';
+
+  propagatedBuildInputs = [
+    freezegun
+    google_api_python_client
+    numpy
+    matplotlib
+    networkx
+    pandas
+    protobuf
+    requests
+    scipy
+    sortedcontainers
+    sympy
+    typing-extensions
+  ];
+
+  doCheck = true;
+  # pythonImportsCheck = [ "cirq" "cirq.Circuit" ];  # cirq's importlib hook doesn't work here
+  dontUseSetuptoolsCheck = true;
+  checkInputs = [
+    pytestCheckHook
+    pytest-benchmark
+    ply
+    pydot
+    pyyaml
+    pygraphviz
+  ];
+
+  pytestFlagsArray = [
+    "--ignore=dev_tools"  # Only needed when developing new code, which is out-of-scope
+    "--ignore=cirq/contrib/"  # requires external (unpackaged) libraries, so untested.
+    "-rfE"
+    "--durations=25"
+    "--disable-warnings"
+    "--benchmark-disable"
+  ];
+  disabledTests = [
+    # These two fail due to outdated pytest syntax
+    "repeat_measurement_keys"
+    "measurement_keys_repeat"
+    "test_convert_to_ion_gates" # seems to fail due to rounding error on CI ONLY, 0.75 != 0.750...2
+  ] ++ lib.optionals stdenv.isAarch64 [
+    # Seem to fail due to math issues on aarch64?
+    "expectation_from_wavefunction"
+    "test_single_qubit_op_to_framed_phase_form_output_on_example_case"
+  ] ++ [
+    # slow tests, for quicker building
+    "test_two_qubit_state_tomography"
+    "test_anneal_search_method_calls"
+    "test_density_matrix_from_state_tomography_is_correct"
+    "test_example_runs_qubit_characterizations"
+    "test_example_runs_hello_line_perf"
+    "test_example_runs_bc_mean_field_perf"
+    "test_main_loop"
+    "test_clifford_circuit_2"
+    "test_decompose_specific_matrices"
+    "test_two_qubit_randomized_benchmarking"
+    "test_kak_decomposition_perf"
+    "test_example_runs_simon"
+    "test_decompose_random_unitary"
+    "test_decompose_size_special_unitary"
+    "test_api_retry_5xx_errors"
+    "test_xeb_fidelity"
+    "test_example_runs_phase_estimator_perf"
+    "test_cross_entropy_benchmarking"
+  ];
+
+  meta = with lib; {
+    description = "A framework for creating, editing, and invoking Noisy Intermediate Scale Quantum (NISQ) circuits.";
+    homepage = "https://github.com/quantumlib/cirq";
+    changelog = "https://github.com/quantumlib/Cirq/releases/tag/v${version}";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ drewrisinger ];
+  };
+}


### PR DESCRIPTION
Meant for aiding in the transition to higher cirq & python versions.