### PR TITLE
python3Packages.qiskit: bump 0.23.0 -> 0.23.1

### DIFF
--- a/pkgs/python-modules/docplex/default.nix
+++ b/pkgs/python-modules/docplex/default.nix
@@ -9,12 +9,12 @@
 
 buildPythonPackage rec {
   pname = "docplex";
-  version = "2.12.182";
+  version = "2.16.196";
 
   # No source available from official repo
   src = fetchPypi {
     inherit pname version;
-    sha256 = "aaf150b06d44f07639aca48be1fca69c7732d57507e6adc4e8451c7a93489116";
+    sha256 = "8fd96e3586444e577b356c0ac62511414e76027ff159ebe0d0b3e44b881406d1";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/python-modules/qiskit-aer/default.nix
+++ b/pkgs/python-modules/qiskit-aer/default.nix
@@ -27,7 +27,7 @@
 
 buildPythonPackage rec {
   pname = "qiskit-aer";
-  version = "0.7.0";
+  version = "0.7.1";
 
   disabled = pythonOlder "3.6";
 
@@ -35,7 +35,7 @@ buildPythonPackage rec {
     owner = "Qiskit";
     repo = "qiskit-aer";
     rev = version;
-    sha256 = "03bj44g3dzsaw05nd2rf1jawyalw9xqbc481qcahv8ms6jw889sy";
+    sha256 = "07l0wavdknx0y4vy0hwgw24365sg4nb6ygl3lpa098np85qgyn4y";
   };
 
   nativeBuildInputs = [

--- a/pkgs/python-modules/qiskit-aqua/default.nix
+++ b/pkgs/python-modules/qiskit-aqua/default.nix
@@ -33,7 +33,7 @@
 
 buildPythonPackage rec {
   pname = "qiskit-aqua";
-  version = "0.8.0";
+  version = "0.8.1";
 
   disabled = pythonOlder "3.6";
 
@@ -42,7 +42,7 @@ buildPythonPackage rec {
     owner = "Qiskit";
     repo = "qiskit-aqua";
     rev = version;
-    sha256 = "1v3mqrisrqpxrpn3z77rj5hb09s1yqa9qvcmmxiamcic6jq96njf";
+    sha256 = "11qyya3vyq50wpzrzzl8v46yx5p72rhpqhybwn47qgazxgg82r1b";
   };
 
   # Optional packages: pyscf (see below NOTE) & pytorch. Can install via pip/nix if needed.

--- a/pkgs/python-modules/qiskit-ibmq-provider/default.nix
+++ b/pkgs/python-modules/qiskit-ibmq-provider/default.nix
@@ -38,7 +38,7 @@ let
 in
 buildPythonPackage rec {
   pname = "qiskit-ibmq-provider";
-  version = "0.11.0";
+  version = "0.11.1";
 
   disabled = pythonOlder "3.6";
 
@@ -46,7 +46,7 @@ buildPythonPackage rec {
     owner = "Qiskit";
     repo = pname;
     rev = version;
-    sha256 = "1pz3vs63v288kxz2qfm9dwhplk0d5x7x8nd7ynbj4n8ycbm0ahks";
+    sha256 = "0b5mnq8f5844idnsmp84lpkvlpszfwwi998yvggcgaayw1dbk53h";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/python-modules/qiskit-ignis/default.nix
+++ b/pkgs/python-modules/qiskit-ignis/default.nix
@@ -17,7 +17,7 @@
 
 buildPythonPackage rec {
   pname = "qiskit-ignis";
-  version = "0.5.0";
+  version = "0.5.1";
 
   disabled = pythonOlder "3.6";
 
@@ -26,7 +26,7 @@ buildPythonPackage rec {
     owner = "Qiskit";
     repo = "qiskit-ignis";
     rev = version;
-    sha256 = "01xsfxw0c699abshpcsajnmvj24l986s4pi48icizxnxl41apjk7";
+    sha256 = "17kplmi17axcbbgw35dzfr3d5bzfymxfni9sf6v14223c5674p4y";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/python-modules/qiskit-terra/default.nix
+++ b/pkgs/python-modules/qiskit-terra/default.nix
@@ -56,7 +56,7 @@ in
 
 buildPythonPackage rec {
   pname = "qiskit-terra";
-  version = "0.16.0";
+  version = "0.16.1";
 
   disabled = pythonOlder "3.6";
 
@@ -64,7 +64,7 @@ buildPythonPackage rec {
     owner = "Qiskit";
     repo = pname;
     rev = version;
-    sha256 = "150sfxgnasd6kn7jjdsh7f41g1vqb8azk6q8yw37ydxlly882kl6";
+    sha256 = "0007glsbrvq9swamvz8r76z9nzh46b388y0ds1dypczxpwlp9xcq";
   };
 
   nativeBuildInputs = [ cython ];

--- a/pkgs/python-modules/qiskit/default.nix
+++ b/pkgs/python-modules/qiskit/default.nix
@@ -15,7 +15,7 @@
 buildPythonPackage rec {
   pname = "qiskit";
   # NOTE: This version denotes a specific set of subpackages. See https://qiskit.org/documentation/release_notes.html#version-history
-  version = "0.23.0";
+  version = "0.23.1";
 
   disabled = pythonOlder "3.6";
 
@@ -23,7 +23,7 @@ buildPythonPackage rec {
     owner = "Qiskit";
     repo = "qiskit";
     rev = version;
-    sha256 = "0r5dz64kcs4vchqy169wmn18dw3dymmd9957fg8zg4550ji89fpz";
+    sha256 = "0x4cqx1wqqj7h5g3vdag694qjzsmvhpw25yrlcs70mh5ywdp28x1";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/python-modules/retworkx/default.nix
+++ b/pkgs/python-modules/retworkx/default.nix
@@ -12,20 +12,20 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "retworkx";
-  version = "0.5.0";
+  version = "0.6.0";
 
   # TODO: remove when 20.09 released, needed to build on CI.
   cargoSha256 = if
     lib.versionOlder lib.trivial.release "20.09"
-    then "0ymb1w74j6bss9sgn5nmm63lj0p1j6zwhdp4f81c7fd3l80jg036"
-    else "12ab7z4mbn71ffqkifkbphg0ga9j8zic5pz9160z7xf1xvd6831d";
+    then "0bnkwp6ggcjd1j273hhww2ikgx9y62182pl55ijiijr963fq7bif"
+    else "1vg4yf0k6yypqf9z46zz818mz7fdrgxj7zl6zjf7pnm2r8mq3qw5";
   legacyCargoFetcher = true;  # TODO: Remove on next nixos release. Cargo SHA mismatch b/w unstable & release.
 
   src = fetchFromGitHub {
     owner = "Qiskit";
     repo = "retworkx";
     rev = version;
-    sha256 = "0gk3cl3vpmkhngi1s1ki5akvqqixd926c902s7x8w73hc5lwdwq7";
+    sha256 = "11n30ldg3y3y6qxg3hbj837pnbwjkqw3nxq6frds647mmmprrd20";
   };
 
   propagatedBuildInputs = [ python ];


### PR DESCRIPTION
Qiskit 0.23.1

Changed
Increased the qiskit-terra version to the latest release 0.16.1
Increased the qiskit-aer version to the latest release 0.7.1
Increased the qiskit-ignis version to the latest release 0.5.1
Increased the qiskit-aqua version to the latest release 0.8.1
Increased the qiskit-ibmq-provider version to the latest release
0.11.1