### PR TITLE
treewide: mark raspberry pi-specific packages

### DIFF
--- a/ci.nix
+++ b/ci.nix
@@ -15,7 +15,7 @@ with builtins;
 let
   isReserved = n: n == "lib" || n == "overlays" || n == "modules";
   isDerivation = p: isAttrs p && p ? type && p.type == "derivation";
-  isBuildable = p: !(p.meta.broken or false) && p.meta.license.free or true;
+  isBuildable = p: !(p.meta.broken or false) && (p.meta.license.free or true) && !(p.meta.isRpiPkg or false);
   isCacheable = p: !(p.preferLocalBuild or false);
   shouldRecurseForDerivations = p: isAttrs p && p.recurseForDerivations or false;
 

--- a/pkgs/raspberrypi/argonone-rpi4/default.nix
+++ b/pkgs/raspberrypi/argonone-rpi4/default.nix
@@ -56,5 +56,6 @@ stdenv.mkDerivation {
     description = "Argon One Service and Control Scripts for Raspberry Pi 4";
     homepage = "https://github.com/Elrondo46/argonone";
     platforms = [ "aarch64-linux" ];  # Raspberry Pi 4
+    isRpiPkg = true;
   };
 }

--- a/pkgs/raspberrypi/gpiozero/default.nix
+++ b/pkgs/raspberrypi/gpiozero/default.nix
@@ -36,5 +36,6 @@ buildPythonPackage rec {
     homepage = "https://gpiozero.readthedocs.io/en/stable/";
     license = licenses.bsd3;
     maintainers = [ maintainers.drewrisinger ];
+    isRpiPkg = true;
   };
 }

--- a/pkgs/raspberrypi/pigpio/default.nix
+++ b/pkgs/raspberrypi/pigpio/default.nix
@@ -24,5 +24,6 @@ stdenv.mkDerivation rec {
     license = licenses.unlicense;
     platforms = [ "aarch64-linux" "armv7l-linux" ]; # targeted at Raspberry Pi ONLY
     maintainers = [ maintainers.drewrisinger ];
+    isRpiPkg = true;
   };
 }

--- a/pkgs/raspberrypi/pigpio/python.nix
+++ b/pkgs/raspberrypi/pigpio/python.nix
@@ -19,5 +19,6 @@ buildPythonPackage rec {
     license = licenses.unlicense;
     platforms = [ "aarch64-linux" "armv7l-linux" ]; # targeted at Raspberry Pi ONLY
     maintainers = [ maintainers.drewrisinger ];
+    isRpiPkg = true;
   };
 }

--- a/pkgs/raspberrypi/rpi-gpio/default.nix
+++ b/pkgs/raspberrypi/rpi-gpio/default.nix
@@ -22,5 +22,6 @@ buildPythonPackage rec {
     homepage = "http://sourceforge.net/p/raspberry-gpio-python/wiki/Home/";
     license = licenses.mit;
     platforms = [ "aarch64-linux" "armv7l-linux" "armv6l-linux" ];
+    isRpiPkg = true;
   };
 }

--- a/pkgs/raspberrypi/rpi-gpio2/default.nix
+++ b/pkgs/raspberrypi/rpi-gpio2/default.nix
@@ -32,5 +32,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/underground-software/RPi.GPIO2";
     license = licenses.gpl3Plus;
     platforms = [ "aarch64-linux" ];
+    isRpiPkg = true;
   };
 }

--- a/pkgs/raspberrypi/steamlink/default.nix
+++ b/pkgs/raspberrypi/steamlink/default.nix
@@ -43,5 +43,6 @@ stdenv.mkDerivation rec {
     homepage = "TODO";
     maintainers = [ maintainers.drewrisinger ];
     platforms = [ "aarch64-linux" "armv7l-linux" "armv6l-linux" ];
+    isRpiPkg = true;
   };
 }

--- a/pkgs/raspberrypi/vc-log/default.nix
+++ b/pkgs/raspberrypi/vc-log/default.nix
@@ -24,5 +24,6 @@ stdenv.mkDerivation {
     license = with licenses; [ unfree ];  # not specified, assuming worst-case
     maintainers = with maintainers; [ drewrisinger ];
     platforms = [ "aarch64-linux" "armv7l-linux" ];
+    isRpiPkg = true;
   };
 }


### PR DESCRIPTION
Useful for avoiding build problems with RPi packages.
All RPi packages in this repo will have the meta attribute
``isRpiPkg`` set to True. CI/cachix will NOT build RPi packages.