### PR TITLE
python3Packages.qiskit-aer: fix build for Duke

### DIFF
--- a/pkgs/python-modules/qiskit-aer/default.nix
+++ b/pkgs/python-modules/qiskit-aer/default.nix
@@ -81,8 +81,14 @@ buildPythonPackage rec {
     "qiskit.providers.aer.backends.qasm_simulator"
     "qiskit.providers.aer.backends.controller_wrappers" # Checks C++ files built correctly. Only exists if built & moved to output
   ];
-  # Slow tests
   disabledTests = [
+    # these fail for some builds. Haven't been able to reproduce error locally.
+    "test_kraus_gate_noise"
+    "test_backend_method_clifford_circuits_and_kraus_noise"
+    "test_backend_method_nonclifford_circuit_and_kraus_noise"
+    "test_kraus_noise_fusion"
+
+    # Slow tests
     "test_paulis_1_and_2_qubits"
     "test_3d_oscillator"
   ];


### PR DESCRIPTION
Disabling failing tests to fix build issues.
Get errors similar to the following according to @b-bondurant.
```
Something went wrong in heevx call within eigensystem_hermitian funcion.
Check that input matrix is really hermitian,
```