### PR TITLE
python3Packages.qiskit-aqua: unpin dependency versions

### DIFF
--- a/pkgs/python-modules/docplex/default.nix
+++ b/pkgs/python-modules/docplex/default.nix
@@ -9,13 +9,12 @@
 
 buildPythonPackage rec {
   pname = "docplex";
-  version = "2.19.202";
-  # Left at this version for qiskit-aqua compatibility: https://github.com/Qiskit/qiskit-optimization/issues/21
+  version = "2.20.204";
 
   # No source available from official repo
   src = fetchPypi {
     inherit pname version;
-    sha256 = "2b606dc645f99feae67dfc528620dddc773ecef5d59bcaeae68bba601f25162b";
+    sha256 = "24d8c3f54b4b1ec306c13b97c9d67e2f9fa93d0d9ea1b92bdba62df6982cd6a0";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/python-modules/qiskit-aqua/default.nix
+++ b/pkgs/python-modules/qiskit-aqua/default.nix
@@ -76,10 +76,13 @@ buildPythonPackage rec {
   # cplex is only distributed in manylinux1 wheel (no source), and Nix python is not manylinux1 compatible
 
   postPatch = ''
-    substituteInPlace setup.py \
-      --replace "pyscf; sys_platform != 'win32'" "" \
-      --replace "cplex; python_version >= '3.6' and python_version < '3.8'" "" \
-      --replace "docplex==2.15.194" "docplex"
+    # Because this is a legacy/final release, the maintainers restricted the maximum
+    # versions of all dependencies to the latest current version. That will not
+    # work with nixpkgs' rolling release/update system.
+    # Unlock all versions for compatibility
+    substituteInPlace setup.py --replace "<=" "~="
+    sed -i 's/\(\w\+-*\w*\).*/\1/' requirements.txt
+    substituteInPlace requirements.txt --replace "dataclasses" ""
 
     # Add ImportWarning when running qiskit.chemistry (pyscf is a chemistry package) that pyscf is not included
     echo -e "\nimport warnings\ntry: import pyscf;\nexcept ImportError:\n    " \


### PR DESCRIPTION
Maintainers pinned because this is a legacy release and they didn't
want to support newer versions of dependency packages, but that
doesn't work with Nix's rolling release system.
