### PR TITLE
python3Packages.cvxpy: add openmp parallelism

### DIFF
--- a/pkgs/python-modules/cvxpy/default.nix
+++ b/pkgs/python-modules/cvxpy/default.nix
@@ -9,6 +9,7 @@
 , osqp
 , scipy
 , scs
+, useOpenmp ? true
   # Check inputs
 , pytestCheckHook
 }:
@@ -16,6 +17,7 @@
 buildPythonPackage rec {
   pname = "cvxpy";
   version = "1.1.12";
+  format = "pyproject";
 
   disabled = pythonOlder "3.5";
 
@@ -32,6 +34,11 @@ buildPythonPackage rec {
     scipy
     scs
   ];
+
+  preBuild = lib.optional useOpenmp ''
+    export CFLAGS="-fopenmp"
+    export LDFLAGS="-lgomp"
+  '';
 
   checkInputs = [ pytestCheckHook ];
   dontUseSetuptoolsCheck = true;

--- a/pkgs/python-modules/cvxpy/default.nix
+++ b/pkgs/python-modules/cvxpy/default.nix
@@ -1,4 +1,5 @@
 { lib
+, stdenv
 , pythonOlder
 , buildPythonPackage
 , fetchPypi
@@ -43,6 +44,8 @@ buildPythonPackage rec {
     "test_cvxopt_sdp"
     "test_psd_nsd_parameters"
     "test_all_solvers"
+  ] ++ lib.optionals stdenv.isAarch64 [
+    "test_ecos_bb_mi_lp_2" # https://github.com/cvxgrp/cvxpy/issues/1241#issuecomment-780912155
   ];
 
   meta = with lib; {


### PR DESCRIPTION
In v 1.1.11, cvxpy added support for OpenMP parallelism,
which should speed up the solving process for certain types of problems.

This PR adds this support.

TODO:
* [x] Upstream to nixpkgs after get working.﻿
