### PR TITLE
python3Packages: init qiskit-* packages, qiskit: 0.25.0 -> 0.25.1

### DIFF
--- a/ci.nix
+++ b/ci.nix
@@ -34,7 +34,7 @@ let
 
   outputsOf = p: map (o: p.${o}) p.outputs;
 
-  nurAttrs = import ./default.nix { inherit pkgs; };
+  nurAttrs = import ./default.nix { rawpkgs = pkgs; };
 
   nurPkgs =
     flattenPkgs

--- a/default.nix
+++ b/default.nix
@@ -120,6 +120,7 @@ rec {
     };
     qiskit-terraNoVisual = qiskit-terra.override { withVisualization = false; };
     qiskit-ibmq-providerNoVisual = qiskit-ibmq-provider.override { withVisualization = false; qiskit-terra = qiskit-terraNoVisual; matplotlib = null; };
+    qiskit-finance = pkgs.python3.pkgs.callPackage ./pkgs/python-modules/qiskit-finance { inherit qiskit-optimization qiskit-terra qiskit-aer fastdtw yfinance; };
     qiskit-optimization = pkgs.python3.pkgs.callPackage ./pkgs/python-modules/qiskit-optimization { inherit pylatexenc qiskit-terra qiskit-aer docplex; };
     qiskit-machine-learning = pkgs.python3.pkgs.callPackage ./pkgs/python-modules/qiskit-machine-learning { inherit qiskit-terra qiskit-aer fastdtw; };
 

--- a/default.nix
+++ b/default.nix
@@ -124,6 +124,7 @@ rec {
     qiskit-optimization = pkgs.python3.pkgs.callPackage ./pkgs/python-modules/qiskit-optimization { inherit pylatexenc qiskit-terra qiskit-aer docplex; };
     qiskit-machine-learning = pkgs.python3.pkgs.callPackage ./pkgs/python-modules/qiskit-machine-learning { inherit qiskit-terra qiskit-aer fastdtw; };
     qiskit-nature = pkgs.python3.pkgs.callPackage ./pkgs/python-modules/qiskit-nature { inherit qiskit-terra pylatexenc retworkx pyscf; };
+    qiskit-ode = pkgs.python3.pkgs.callPackage ./pkgs/python-modules/qiskit-ode { inherit qiskit-terra; };
 
     # Raspberry Pi Packages
     colorzero = pkgs.python3Packages.callPackage ./pkgs/raspberrypi/colorzero { };

--- a/default.nix
+++ b/default.nix
@@ -116,7 +116,17 @@ rec {
       inherit ipyvuetify pproxy qiskit-terra qiskit-aer;
     };
     qiskit = pkgs.python3.pkgs.callPackage ./pkgs/python-modules/qiskit {
-      inherit qiskit-aer qiskit-terra qiskit-ignis qiskit-aqua qiskit-ibmq-provider;
+      inherit
+        qiskit-aer
+        qiskit-terra
+        qiskit-ignis
+        qiskit-aqua
+        qiskit-ibmq-provider
+        qiskit-finance
+        qiskit-machine-learning
+        qiskit-nature
+        qiskit-optimization
+        ;
     };
     qiskit-terraNoVisual = qiskit-terra.override { withVisualization = false; };
     qiskit-ibmq-providerNoVisual = qiskit-ibmq-provider.override { withVisualization = false; qiskit-terra = qiskit-terraNoVisual; matplotlib = null; };

--- a/default.nix
+++ b/default.nix
@@ -6,7 +6,7 @@
 # commands such as:
 #     nix-build -A mypackage
 
-{ pkgs ? import <nixpkgs> { } }:
+{ rawpkgs ? import <nixpkgs> { } }:
 
 rec {
   # The `lib`, `modules`, and `overlay` names are special
@@ -15,7 +15,7 @@ rec {
   overlays = import ./overlays; # nixpkgs overlays
 
   # NOTE: default pkgs to updated versions as required by packages
-  # pkgs = rawpkgs.appendOverlays [ overlays.python-updates ];
+  pkgs = rawpkgs.appendOverlays [ overlays.python-updates ];
 
   # Packages/updates accepted to nixpkgs/master, but need the update
   lib-scs = pkgs.callPackage ./pkgs/libraries/scs { };

--- a/default.nix
+++ b/default.nix
@@ -120,6 +120,7 @@ rec {
     };
     qiskit-terraNoVisual = qiskit-terra.override { withVisualization = false; };
     qiskit-ibmq-providerNoVisual = qiskit-ibmq-provider.override { withVisualization = false; qiskit-terra = qiskit-terraNoVisual; matplotlib = null; };
+    qiskit-optimization = pkgs.python3.pkgs.callPackage ./pkgs/python-modules/qiskit-optimization { inherit pylatexenc qiskit-terra qiskit-aer docplex; };
 
     # Raspberry Pi Packages
     colorzero = pkgs.python3Packages.callPackage ./pkgs/raspberrypi/colorzero { };

--- a/default.nix
+++ b/default.nix
@@ -121,6 +121,7 @@ rec {
     qiskit-terraNoVisual = qiskit-terra.override { withVisualization = false; };
     qiskit-ibmq-providerNoVisual = qiskit-ibmq-provider.override { withVisualization = false; qiskit-terra = qiskit-terraNoVisual; matplotlib = null; };
     qiskit-optimization = pkgs.python3.pkgs.callPackage ./pkgs/python-modules/qiskit-optimization { inherit pylatexenc qiskit-terra qiskit-aer docplex; };
+    qiskit-machine-learning = pkgs.python3.pkgs.callPackage ./pkgs/python-modules/qiskit-machine-learning { inherit qiskit-terra qiskit-aer fastdtw; };
 
     # Raspberry Pi Packages
     colorzero = pkgs.python3Packages.callPackage ./pkgs/raspberrypi/colorzero { };

--- a/default.nix
+++ b/default.nix
@@ -123,6 +123,7 @@ rec {
     qiskit-finance = pkgs.python3.pkgs.callPackage ./pkgs/python-modules/qiskit-finance { inherit qiskit-optimization qiskit-terra qiskit-aer fastdtw yfinance; };
     qiskit-optimization = pkgs.python3.pkgs.callPackage ./pkgs/python-modules/qiskit-optimization { inherit pylatexenc qiskit-terra qiskit-aer docplex; };
     qiskit-machine-learning = pkgs.python3.pkgs.callPackage ./pkgs/python-modules/qiskit-machine-learning { inherit qiskit-terra qiskit-aer fastdtw; };
+    qiskit-nature = pkgs.python3.pkgs.callPackage ./pkgs/python-modules/qiskit-nature { inherit qiskit-terra pylatexenc retworkx pyscf; };
 
     # Raspberry Pi Packages
     colorzero = pkgs.python3Packages.callPackage ./pkgs/raspberrypi/colorzero { };

--- a/overlays/python-updates.nix
+++ b/overlays/python-updates.nix
@@ -16,7 +16,8 @@ rec {
           localPyPackage;
     in
     {
-      # None currently needed for nixpkgs-20.03+
+      # Needed for nixpkgs-20.03
+      sparse = overrideSuperVersionIfNewer py-super.sparse (py-self.callPackage ../pkgs/python-modules/sparse { });
     };
   };
 

--- a/pkgs/libraries/tweedledum/default.nix
+++ b/pkgs/libraries/tweedledum/default.nix
@@ -1,4 +1,5 @@
 { stdenv
+, lib
 , fetchFromGitHub
 , cmake
 , fmt
@@ -44,7 +45,7 @@ stdenv.mkDerivation rec {
     ./test/run_tests
   '';
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "Library for writing, manipulating, and optimizing quantum circuits";
     homepage = "https://github.com/boschmitt/tweedledum";
     license = licenses.mit ;

--- a/pkgs/python-modules/qiskit-aer/default.nix
+++ b/pkgs/python-modules/qiskit-aer/default.nix
@@ -27,7 +27,7 @@
 
 buildPythonPackage rec {
   pname = "qiskit-aer";
-  version = "0.8.0";
+  version = "0.8.1";
   format = "pyproject";
 
   disabled = pythonOlder "3.6";
@@ -36,7 +36,7 @@ buildPythonPackage rec {
     owner = "Qiskit";
     repo = "qiskit-aer";
     rev = version;
-    sha256 = "1ylpl1b7yh79vqkg80ax2xrhh309nszxdxc1kmbp1l7c29x7fq89";
+    sha256 = "1f1s2jm8y13plkmpdnm2jsji5rvzd72f3q186v1g2ql21sl2i07g";
   };
 
   # The default check for the dl library will erroneously fail (and building with it w/ buildInputs = [... glibc ] fails too).

--- a/pkgs/python-modules/qiskit-aqua/default.nix
+++ b/pkgs/python-modules/qiskit-aqua/default.nix
@@ -33,7 +33,7 @@
 
 buildPythonPackage rec {
   pname = "qiskit-aqua";
-  version = "0.9.0";
+  version = "0.9.1";
 
   disabled = pythonOlder "3.6";
 
@@ -42,7 +42,7 @@ buildPythonPackage rec {
     owner = "Qiskit";
     repo = "qiskit-aqua";
     rev = version;
-    sha256 = "046sgv533ilg5syic4bqi6d7h3q0gmv7sbvv82abv1v2wbv9wywj";
+    sha256 = "0rc63bqv7101rnl1adqf5gymf5rrv1h14r9va9vhjlp4zal756vy";
   };
 
   # Optional packages: pyscf (see below NOTE) & pytorch. Can install via pip/nix if needed.

--- a/pkgs/python-modules/qiskit-finance/default.nix
+++ b/pkgs/python-modules/qiskit-finance/default.nix
@@ -1,0 +1,78 @@
+{ lib
+, pythonOlder
+, buildPythonPackage
+, fetchFromGitHub
+  # Python Inputs
+, fastdtw
+, numpy
+, pandas
+, psutil
+, qiskit-terra
+, qiskit-optimization
+, scikitlearn
+, scipy
+, quandl
+, yfinance
+  # Check Inputs
+, pytestCheckHook
+, ddt
+, pytest-timeout
+, qiskit-aer
+}:
+
+buildPythonPackage rec {
+  pname = "qiskit-finance";
+  version = "0.1.0";
+
+  disabled = pythonOlder "3.6";
+
+  src = fetchFromGitHub {
+    owner = "Qiskit";
+    repo = pname;
+    rev = version;
+    sha256 = "0kxhv53hc2n6icwywli6dsvidbk6smmrrv630jvwp94cxs1lynpq";
+  };
+
+  propagatedBuildInputs = [
+    fastdtw
+    numpy
+    pandas
+    psutil
+    qiskit-terra
+    qiskit-optimization
+    quandl
+    scikitlearn
+    scipy
+    yfinance
+  ];
+
+  checkInputs = [
+    pytestCheckHook
+    pytest-timeout
+    ddt
+    qiskit-aer
+  ];
+  dontUseSetuptoolsCheck = true;
+
+  pythonImportsCheck = [ "qiskit_finance" ];
+  preCheck = "pushd $TMP/$sourceRoot";
+  postCheck = "popd";
+  disabledTests = [
+    # Tests fail b/c require internet connection. Stalls tests if enabled.
+    "test_exchangedata"
+    "test_yahoo"
+    "test_wikipedia"
+  ];
+  pytestFlagsArray = [
+    "--durations=10"
+  ];
+
+  meta = with lib; {
+    description = "Software for developing quantum computing programs";
+    homepage = "https://qiskit.org";
+    downloadPage = "https://github.com/QISKit/qiskit-optimization/releases";
+    changelog = "https://qiskit.org/documentation/release_notes.html";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ drewrisinger ];
+  };
+}

--- a/pkgs/python-modules/qiskit-machine-learning/default.nix
+++ b/pkgs/python-modules/qiskit-machine-learning/default.nix
@@ -1,0 +1,93 @@
+{ lib
+, pythonOlder
+, buildPythonPackage
+, fetchFromGitHub
+, fetchpatch
+  # Python Inputs
+, fastdtw
+, numpy
+, psutil
+, qiskit-terra
+, scikitlearn
+, sparse
+  # Optional inputs
+  # Fails some tests with older version of torch on nixos-20.03, easier just to disable
+, withTorch ? (lib.versionAtLeast lib.trivial.version "20.09")
+, pytorch
+  # Check Inputs
+, pytestCheckHook
+, ddt
+, pytest-timeout
+, qiskit-aer
+}:
+
+buildPythonPackage rec {
+  pname = "qiskit-machine-learning";
+  version = "0.1.0";
+
+  disabled = pythonOlder "3.6";
+
+  src = fetchFromGitHub {
+    owner = "Qiskit";
+    repo = pname;
+    rev = version;
+    sha256 = "0x9hvvjlpf30993y7wlyqgfh8paiskiw0qd24h9xi7ip65b1qvrv";
+  };
+
+  patches = [
+    (fetchpatch {
+      name = "qiskit-machine-learning-pr-55-torch-optional-tests.patch";
+      url = "https://github.com/Qiskit/qiskit-machine-learning/commit/89bc4308bab42637b91aca8f353ac219d99f93d0.patch";
+      sha256 = "1lf6s65b3i1q2s5dfv4k9l1f0njm93b7biz4kr8ggwwmrqy7pmli";
+    })
+  ];
+
+  propagatedBuildInputs = [
+    fastdtw
+    numpy
+    psutil
+    qiskit-terra
+    scikitlearn
+    sparse
+  ] ++ lib.optional withTorch pytorch;
+
+  checkInputs = [
+    pytestCheckHook
+    pytest-timeout
+    ddt
+    qiskit-aer
+  ];
+  dontUseSetuptoolsCheck = true;
+
+  pythonImportsCheck = [ "qiskit_machine_learning" ];
+  preCheck = "pushd $TMP/$sourceRoot";
+  postCheck = "popd";
+
+  pytestFlagsArray = [
+    "--durations=10"
+  ];
+  disabledTests = [
+    # Slow tests >10 s
+    "test_vqr_8"
+    "test_vqr_7"
+    "test_qgan_training_cg"
+    "test_vqc_4"
+    "test_classifier_with_circuit_qnn_and_cross_entropy_4"
+    "test_vqr_4"
+    "test_regressor_with_opflow_qnn_4"
+    "test_qgan_save_model"
+    "test_qgan_training_analytic_gradients"
+    "test_qgan_training_run_algo_numpy"
+    "test_ad_hoc_data"
+    "test_qgan_training"
+  ];
+
+  meta = with lib; {
+    description = "Software for developing quantum computing programs";
+    homepage = "https://qiskit.org";
+    downloadPage = "https://github.com/QISKit/qiskit-optimization/releases";
+    changelog = "https://qiskit.org/documentation/release_notes.html";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ drewrisinger ];
+  };
+}

--- a/pkgs/python-modules/qiskit-nature/default.nix
+++ b/pkgs/python-modules/qiskit-nature/default.nix
@@ -1,0 +1,75 @@
+{ lib
+, pythonOlder
+, buildPythonPackage
+, fetchFromGitHub
+  # Python Inputs
+, h5py
+, numpy
+, psutil
+, qiskit-terra
+, retworkx
+, scikitlearn
+, scipy
+, withPyscf ? false
+, pyscf
+  # Check Inputs
+, pytestCheckHook
+, ddt
+, pylatexenc
+}:
+
+buildPythonPackage rec {
+  pname = "qiskit-nature";
+  version = "0.1.1";
+
+  disabled = pythonOlder "3.6";
+
+  src = fetchFromGitHub {
+    owner = "Qiskit";
+    repo = pname;
+    rev = version;
+    sha256 = "1niapmpwvnqhql1wc6jv81j9pda4mm3gr8i3s7x9z1a43ks7sxxq";
+  };
+
+  propagatedBuildInputs = [
+    h5py
+    numpy
+    psutil
+    qiskit-terra
+    retworkx
+    scikitlearn
+    scipy
+  ] ++ lib.optional withPyscf pyscf;
+
+  checkInputs = [
+    pytestCheckHook
+    ddt
+    pylatexenc
+  ];
+  dontUseSetuptoolsCheck = true;
+
+  pythonImportsCheck = [ "qiskit_nature" ];
+  preCheck = "pushd $TMP/$sourceRoot";
+  postCheck = "popd";
+
+  pytestFlagsArray = lib.optionals (!withPyscf) [
+    "--ignore=test/algorithms/excited_state_solvers/test_excited_states_eigensolver.py"
+  ];
+
+  disabledTests = [
+    # Fails on GitHub Actions, small math error < 0.05 (< 9e-6 %)
+    "test_vqe_uvccsd_factory"
+  ] ++ lib.optionals (!withPyscf) [
+    "test_h2_bopes_sampler"
+    "test_potential_interface"
+  ];
+
+  meta = with lib; {
+    description = "Software for developing quantum computing programs";
+    homepage = "https://qiskit.org";
+    downloadPage = "https://github.com/QISKit/qiskit-optimization/releases";
+    changelog = "https://qiskit.org/documentation/release_notes.html";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ drewrisinger ];
+  };
+}

--- a/pkgs/python-modules/qiskit-ode/default.nix
+++ b/pkgs/python-modules/qiskit-ode/default.nix
@@ -1,0 +1,55 @@
+{ lib
+, pythonOlder
+, buildPythonPackage
+, fetchFromGitHub
+  # Python Inputs
+, matplotlib
+, numpy
+, qiskit-terra
+, scipy
+  # Check Inputs
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "qiskit-ode";
+  version = "unstable-2021-04-12";
+  format = "pyproject";
+
+  disabled = pythonOlder "3.6";
+
+  src = fetchFromGitHub {
+    owner = "Qiskit";
+    repo = "qiskit-ode";
+    rev = "21fed791780886ffe1490cf255c2078cc162520a";
+    sha256 = "1aijmg39gnj1yma4d406zichdjwyrrvp8aiampv4kffmj4ly6p24";
+  };
+
+  propagatedBuildInputs = [
+    matplotlib
+    numpy
+    qiskit-terra
+    scipy
+  ];
+
+  checkInputs = [ pytestCheckHook ];
+  dontUseSetuptoolsCheck = true;
+
+  pythonImportsCheck = [ "qiskit_ode" ];
+  preCheck = "pushd $TMP/$sourceRoot";
+  postCheck = "popd";
+
+  disabledTests = [
+    # These tests fail "TypeError: ufunc 'nextafter' not supported for the input types, and the inputs could not be safely coerced to any supported types according to the casting rule ''safe''"
+    "test_solve_ode_w_GeneratorModel"
+    "test_standard_problems_solve_ivp"
+  ];
+
+  meta = with lib; {
+    description = "ODE solver tools in Qiskit";
+    homepage = "https://qiskit.org";
+    downloadPage = "https://github.com/qiskit/qiskit-ode";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ drewrisinger ];
+  };
+}

--- a/pkgs/python-modules/qiskit-optimization/default.nix
+++ b/pkgs/python-modules/qiskit-optimization/default.nix
@@ -1,0 +1,61 @@
+{ lib
+, pythonOlder
+, buildPythonPackage
+, fetchFromGitHub
+  # Python Inputs
+, decorator
+, docplex
+, networkx
+, numpy
+, qiskit-terra
+, scipy
+  # Check Inputs
+, pytestCheckHook
+, ddt
+, pylatexenc
+, qiskit-aer
+}:
+
+buildPythonPackage rec {
+  pname = "qiskit-optimization";
+  version = "0.1.0";
+
+  disabled = pythonOlder "3.6";
+
+  src = fetchFromGitHub {
+    owner = "Qiskit";
+    repo = pname;
+    rev = version;
+    sha256 = "11rym9gzd4dd0mh1kzfbp4nf71w2i7lx18605k4d5f3f4kn3vlx5";
+  };
+
+  propagatedBuildInputs = [
+    docplex
+    decorator
+    networkx
+    numpy
+    qiskit-terra
+    scipy
+  ];
+
+  checkInputs = [
+    pytestCheckHook
+    ddt
+    pylatexenc
+    qiskit-aer
+  ];
+  dontUseSetuptoolsCheck = true;
+
+  pythonImportsCheck = [ "qiskit_optimization" ];
+  preCheck = "pushd $TMP/$sourceRoot";
+  postCheck = "popd";
+
+  meta = with lib; {
+    description = "Software for developing quantum computing programs";
+    homepage = "https://qiskit.org";
+    downloadPage = "https://github.com/QISKit/qiskit-optimization/releases";
+    changelog = "https://qiskit.org/documentation/release_notes.html";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ drewrisinger ];
+  };
+}

--- a/pkgs/python-modules/qiskit-terra/default.nix
+++ b/pkgs/python-modules/qiskit-terra/default.nix
@@ -2,7 +2,6 @@
 , pythonOlder
 , buildPythonPackage
 , fetchFromGitHub
-, fetchpatch
   # Python requirements
 , cython
 , dill
@@ -57,7 +56,7 @@ in
 
 buildPythonPackage rec {
   pname = "qiskit-terra";
-  version = "0.17.0";
+  version = "0.17.1";
 
   disabled = pythonOlder "3.6";
 
@@ -65,17 +64,8 @@ buildPythonPackage rec {
     owner = "Qiskit";
     repo = pname;
     rev = version;
-    sha256 = "0wlpkw0b8kxmjz2fis2n8126psbhn3mqwgdpc2wm208nf1l5pcrd";
+    sha256 = "1wwjwwfs79bq7cz7354048g1gp2j30kp238fpkrlvhhj4i80c408";
   };
-
-  patches = [
-    # TODO: Remove on next version. Merged to master
-    (fetchpatch {
-      name = "qiskit-terra-pr-6213-fix-seconds-to-samples.patch";
-      url = "https://github.com/Qiskit/qiskit-terra/commit/40ffd2b07c03e220a174b2bfd0bf8c23aa021c5f.patch";
-      sha256 = "19j3w9xmzwcazkdfgiar4v7hsnf2sy9xaym1qg70lh5qvwad0b3s";
-    })
-  ];
 
   nativeBuildInputs = [ cython ];
 

--- a/pkgs/python-modules/qiskit/default.nix
+++ b/pkgs/python-modules/qiskit/default.nix
@@ -29,7 +29,7 @@ in
 buildPythonPackage rec {
   pname = "qiskit";
   # NOTE: This version denotes a specific set of subpackages. See https://qiskit.org/documentation/release_notes.html#version-history
-  version = "0.25.0";
+  version = "0.25.1";
 
   disabled = pythonOlder "3.6";
 
@@ -37,7 +37,7 @@ buildPythonPackage rec {
     owner = "Qiskit";
     repo = "qiskit";
     rev = version;
-    sha256 = "0kaa1pc4fi90xasr1c32j71363j1pipmrl0vgd0cy5ijf1vkm4x4";
+    sha256 = "1m5zdbggan21gqd0sxjgr6yk35pfkrgvg40al36c00givvrm9sd4";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/python-modules/qiskit/default.nix
+++ b/pkgs/python-modules/qiskit/default.nix
@@ -8,10 +8,24 @@
 , qiskit-ibmq-provider
 , qiskit-ignis
 , qiskit-terra
+  # Optional inputs
+, withOptionalPackages ? true
+, qiskit-finance
+, qiskit-machine-learning
+, qiskit-nature
+, qiskit-optimization
   # Check Inputs
 , pytestCheckHook
 }:
 
+let
+  optionalQiskitPackages = [
+    qiskit-finance
+    qiskit-machine-learning
+    qiskit-nature
+    qiskit-optimization
+  ];
+in
 buildPythonPackage rec {
   pname = "qiskit";
   # NOTE: This version denotes a specific set of subpackages. See https://qiskit.org/documentation/release_notes.html#version-history
@@ -32,7 +46,7 @@ buildPythonPackage rec {
     qiskit-ibmq-provider
     qiskit-ignis
     qiskit-terra
-  ];
+  ] ++ lib.optionals withOptionalPackages optionalQiskitPackages;
 
   checkInputs = [ pytestCheckHook ];
   dontUseSetuptoolsCheck = true;

--- a/pkgs/python-modules/sparse/default.nix
+++ b/pkgs/python-modules/sparse/default.nix
@@ -1,0 +1,43 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, isPy3k
+, numba
+, numpy
+, scipy
+  # Test Inputs
+, pytestCheckHook
+, dask
+}:
+
+buildPythonPackage rec {
+  pname = "sparse";
+  version = "0.9.1";
+
+  disabled = !isPy3k;
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "04gfwm1y9knryx992biniqa3978n3chr38iy3y4i2b8wy52fzy3d";
+  };
+
+  propagatedBuildInputs = [
+    numba
+    numpy
+    scipy
+  ];
+  checkInputs = [ pytestCheckHook dask ];
+  dontUseSetuptoolsCheck = true;
+  preCheck = "pushd $TMPDIR/$sourceRoot";
+  postCheck = "popd";
+
+  pythonImportsCheck = [ "sparse" ];
+
+  meta = with lib; {
+    description = "Sparse n-dimensional arrays computations";
+    homepage = "https://sparse.pydata.org/en/stable/";
+    changelog = "https://sparse.pydata.org/en/stable/changelog.html";
+    license = licenses.bsd3;
+    maintainers = [ maintainers.costrouc ];
+  };
+}

--- a/pkgs/python-modules/yfinance/default.nix
+++ b/pkgs/python-modules/yfinance/default.nix
@@ -12,13 +12,13 @@
 
 buildPythonPackage rec {
   pname = "yfinance";
-  version = "0.1.55";
+  version = "0.1.59";
 
   src = fetchFromGitHub {
     owner = "ranaroussi";
     repo = pname;
-    rev = version;
-    sha256 = "0484jsi526gdas0k1i50fapl4wi272jfgskw480h6m78xs8asz4q";
+    rev = "eb42fbfbcd5beca3f08b1eb0dce59b6e531bb211"; # untagged :(
+    sha256 = "010ws97vlj2dvbdnzf1xmlmicgdbmkkhpf2n948wcfsczyd7v5kh";
   };
 
   propagatedBuildInputs = [


### PR DESCRIPTION
Adds new packages that split out qiskit functionality.

Qiskit-aqua is being deprecated, and its functionality is being split into
new subpackages:
* qiskit-optimization
* qiskit-machine-learning
* qiskit-finance
* qiskit-nature
* qiskit-ode

Other updates:
* python3Packages.yfinance: 0.1.55 -> 0.1.59 - 
* python3Packages.qiskit-terra: 0.17.0 -> 0.17.1
* python3Packages.qiskit-aer: 0.8.0 -> 0.8.1
* python3Packages.qiskit-aqua: 0.9.0 -> 0.9.1