### PR TITLE
python3Packages.tweedledum: remove test dir from output

### DIFF
--- a/pkgs/python-modules/tweedledum/default.nix
+++ b/pkgs/python-modules/tweedledum/default.nix
@@ -14,6 +14,11 @@ buildPythonPackage rec {
   inherit (libtweedledum) version src;
   format = "pyproject";
 
+  # TODO: remove in next version
+  postPatch = ''
+    substituteInPlace setup.py --replace "where='python'" "where='python', exclude=('test',)"
+  '';
+
   nativeBuildInputs = [ cmake ninja scikit-build ];
   dontUseCmakeConfigure = true;
 


### PR DESCRIPTION
Added b/c I had a conflict b/w this & another package. Basically, they both added the /test dir to their output, which caused a collision when Nix was building a python environment with both of them.