### PR TITLE
python3Packages.cirq: 0.10.0 -> 0.11.0

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -72,7 +72,7 @@ rec {
     pyvisa-py = pkgs.python3.pkgs.callPackage ./pkgs/python-modules/pyvisa-py { inherit pyvisa; };
 
     # More recent version than in Nixpkgs
-    cirq = pkgs.python3.pkgs.callPackage ./pkgs/python-modules/cirq { withContribRequires = false; inherit pyquil quimb; };
+    inherit (pkgs.python3.pkgs.callPackage ./pkgs/python-modules/cirq { }) cirq-core cirq-google cirq;
     cvxpy = pkgs.python3.pkgs.callPackage ./pkgs/python-modules/cvxpy { inherit ecos osqp scs; };
     ecos = pkgs.python3.pkgs.callPackage ./pkgs/python-modules/ecos { };
     qdldl = pkgs.python3Packages.callPackage ./pkgs/python-modules/qdldl { };

--- a/pkgs/python-modules/cirq/default.nix
+++ b/pkgs/python-modules/cirq/default.nix
@@ -20,124 +20,142 @@
 , typing-extensions
   # Contrib requirements
 , withContribRequires ? false
+, autoray ? null
+, opt-einsum
+, ply
+, pylatex ? null
 , pyquil ? null
 , quimb ? null
   # test inputs
 , pytestCheckHook
 , freezegun
 , pytest-asyncio
-, pytest-benchmark
-, ply
-, pydot
-, pyyaml
-, pygraphviz
 }:
 
-assert (lib.versionOlder lib.trivial.release "21.03") -> google_api_core != null && google-api-core == null;
-assert (lib.versionAtLeast lib.trivial.release "21.03") -> google-api-core != null && google_api_core == null;
-buildPythonPackage rec {
-  pname = "cirq";
-  version = "0.10.0";
-
-  disabled = pythonOlder "3.6";
-
+let
+  version = "0.11.0";
   src = fetchFromGitHub {
     owner = "quantumlib";
     repo = "cirq";
     rev = "v${version}";
-    sha256 = "0xinml44n2lfl0q2lb2apmn69gsszlwim83082f66vyk0gpwd4lr";
+    sha256 = "0z51p1529awz0c55c97lhjk6wd7hd2l1jlkydw2k51qqg4d978i5";
   };
+  disabled = pythonOlder "3.6";
+  cirq-core = buildPythonPackage rec {
+    pname = "cirq-core";
+    inherit version src disabled;
 
-  postPatch = ''
-    substituteInPlace requirements.txt \
-      --replace "matplotlib~=3.0" "matplotlib" \
-      --replace "networkx~=2.4" "networkx" \
-      --replace "numpy~=1.16" "numpy" \
-      --replace "protobuf~=3.13.0" "protobuf"
-  '';
+    sourceRoot = "source/${pname}";
 
-  propagatedBuildInputs = [
-    # google-api-core == google_api_core, just renamed on nixpkgs >= 20.03
-    google_api_core
-    google-api-core
-    matplotlib
-    networkx
-    numpy
-    pandas
-    protobuf
-    requests
-    scipy
-    sortedcontainers
-    sympy
-    tqdm
-    typing-extensions
-  ] ++ lib.optionals withContribRequires [
-    pyquil
-    quimb
-  ];
+    postPatch = ''
+      substituteInPlace requirements.txt \
+        --replace "matplotlib~=3.0" "matplotlib" \
+        --replace "networkx~=2.4" "networkx" \
+        --replace "numpy~=1.16" "numpy" \
+        --replace "requests~=2.18" "requests"
+    '';
 
-  doCheck = true;
-  # pythonImportsCheck = [ "cirq" "cirq.Circuit" ];  # cirq's importlib hook doesn't work here
-  dontUseSetuptoolsCheck = true;
-  checkInputs = [
-    pytestCheckHook
-    freezegun
-    pytest-asyncio
-    pytest-benchmark
-    ply
-    pydot
-    pyyaml
-    pygraphviz
-  ];
+    propagatedBuildInputs = [
+      matplotlib
+      networkx
+      numpy
+      pandas
+      requests
+      scipy
+      sortedcontainers
+      sympy
+      tqdm
+      typing-extensions
+    ] ++ lib.optionals withContribRequires [
+      autoray
+      opt-einsum
+      ply
+      pylatex
+      pyquil
+      quimb
+    ];
 
-  pytestFlagsArray = [
-    "--ignore=dev_tools"  # Only needed when developing new code, which is out-of-scope
-    "-rfE"
-    # "--durations=25"
-    "--benchmark-disable"
-  ] ++ lib.optionals (!withContribRequires) [
-    # requires external (unpackaged) libraries, so untested.
-    "--ignore=cirq/contrib/quimb/"
-    "--ignore=cirq/contrib/quil_import/"
-  ];
-  # TODO: remove disables before aarch64 on NixOS 20.09+, working protobuf version.
-  disabledTests = [
-    "test_benchmark_2q_xeb_fidelities" # fails due pandas MultiIndex. Maybe issue with pandas version in nix?
-    "test_convert_to_ion_gates" # seems to fail due to rounding error on CI ONLY, 0.75 != 0.750...2
-  ] ++ lib.optionals (lib.versionOlder protobuf.version "3.9.0") [
-    "engine_job_test"
-    "test_health"
-    "test_run_delegation"
-  ] ++ lib.optionals stdenv.hostPlatform.isAarch64 [
-    # Seem to fail due to math issues on aarch64?
-    "expectation_from_wavefunction"
-    "test_single_qubit_op_to_framed_phase_form_output_on_example_case"
-  ] ++ [
-    # slow tests, for quicker building
-    "test_anneal_search_method_calls"
-    "test_density_matrix_from_state_tomography_is_correct"
-    "test_example_runs_qubit_characterizations"
-    "test_example_runs_hello_line_perf"
-    "test_example_runs_bc_mean_field_perf"
-    "test_main_loop"
-    "test_clifford_circuit_2"
-    "test_decompose_specific_matrices"
-    "test_two_qubit_randomized_benchmarking"
-    "test_kak_decomposition_perf"
-    "test_example_runs_simon"
-    "test_decompose_random_unitary"
-    "test_decompose_size_special_unitary"
-    "test_api_retry_5xx_errors"
-    "test_xeb_fidelity"
-    "test_example_runs_phase_estimator_perf"
-    "test_cross_entropy_benchmarking"
-  ];
+    checkInputs = [
+      pytestCheckHook
+      pytest-asyncio
+      freezegun
+    ];
+    dontUseSetuptoolsCheck = true;
 
-  meta = with lib; {
-    description = "A framework for creating, editing, and invoking Noisy Intermediate Scale Quantum (NISQ) circuits.";
-    homepage = "https://github.com/quantumlib/cirq";
-    changelog = "https://github.com/quantumlib/Cirq/releases/tag/v${version}";
-    license = licenses.asl20;
-    maintainers = with maintainers; [ drewrisinger ];
+    pytestFlagsArray = [
+      "-rfE"
+      # "--durations=10"
+    ] ++ lib.optionals (!withContribRequires) [
+      # requires external (unpackaged) libraries, so untested.
+      "--ignore=cirq/contrib/"
+    ];
+    disabledTests = [
+      "test_metadata_search_path" # tries to import flynt, which isn't in Nixpkgs
+      "test_benchmark_2q_xeb_fidelities" # fails due pandas MultiIndex. Maybe issue with pandas version in nix?
+    ] ++ lib.optionals stdenv.hostPlatform.isAarch64 [
+      # Seem to fail due to math issues on aarch64?
+      "expectation_from_wavefunction"
+      "test_single_qubit_op_to_framed_phase_form_output_on_example_case"
+    ];
+
+    meta = with lib; {
+      description = "A framework for creating, editing, and invoking Noisy Intermediate Scale Quantum (NISQ) circuits.";
+      homepage = "https://github.com/quantumlib/cirq";
+      changelog = "https://github.com/quantumlib/Cirq/releases/tag/v${version}";
+      license = licenses.asl20;
+      maintainers = with maintainers; [ drewrisinger ];
+    };
   };
+  cirq-google = buildPythonPackage rec {
+    pname = "cirq-google";
+    inherit version src disabled;
+    sourceRoot = "source/${pname}";
+    inherit (cirq-core) meta;
+
+    postPatch = ''
+      substituteInPlace requirements.txt --replace "protobuf~=3.13.0" "protobuf"
+    '';
+
+    propagatedBuildInputs = [
+      cirq-core
+      google_api_core
+      google-api-core
+      protobuf
+    ];
+
+    dontUseSetuptoolsCheck = true;
+    checkInputs = [ pytestCheckHook freezegun ];
+    disabledTests = lib.optionals (lib.versionOlder protobuf.version "3.9.0") [
+      "engine_job_test"
+      "test_health"
+      "test_run_delegation"
+    ];
+  };
+  cirq = buildPythonPackage rec {
+    pname = "cirq";
+    inherit version src disabled;
+
+    preCheck = ''
+      rm -rf cirq-core
+      rm -rf cirq-google
+    '';
+
+    propagatedBuildInputs = [
+      cirq-core
+      cirq-google
+    ];
+
+    dontUseSetuptoolsCheck = true;
+    checkInputs = [ pytestCheckHook ];
+    pytestFlagsArray = [
+      "--ignore=dev_tools"
+    ];
+
+    inherit (cirq-core) meta;
+  };
+in
+assert (lib.versionOlder lib.trivial.release "21.05") -> google_api_core != null && google-api-core == null;
+assert (lib.versionAtLeast lib.trivial.release "21.05") -> google-api-core != null && google_api_core == null;
+{
+  inherit cirq cirq-core cirq-google;
 }

--- a/pkgs/python-modules/openfermion/default.nix
+++ b/pkgs/python-modules/openfermion/default.nix
@@ -33,6 +33,11 @@ buildPythonPackage rec {
       url = "https://github.com/quantumlib/OpenFermion/commit/10637dab77bbf73d066c789b2a59ead4f4ad6996.patch";
       sha256 = "01i8kqrnkz7w5x43sc7qll2hcmp9s2xdcxvvy1wyagzggx0yk9q9";
     })
+    (fetchpatch {
+      name = "openfermion-update-to-cirq-0_11_0.patch";
+      url = "https://github.com/quantumlib/OpenFermion/commit/b9becd72f7af283d867d219d7ee6df8942ac870f.patch";
+      sha256 = "0fwp3r142zg7b5vmmgwh67s0scnpbahbwaqj1759v01x1ai6fp0b";
+    })
   ];
 
   propagatedBuildInputs = [


### PR DESCRIPTION
Splits the main package into two subpackages: cirq-core & cirq-google.
These can now be accessed separately. See release notes for full
details.
https://github.com/quantumlib/Cirq/releases/tag/v0.11.0
