### PR TITLE
CI: update actions to latest version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,13 +39,13 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v2.3.4
     - name: Install nix
-      uses: cachix/install-nix-action@v12
+      uses: cachix/install-nix-action@v13
       with:
         nix_path: "${{ matrix.nixPath }}"
     - name: Show nixpkgs version
       run: nix-instantiate --eval -E '(import <nixpkgs> {}).lib.version'
     - name: Setup cachix
-      uses: cachix/cachix-action@v8
+      uses: cachix/cachix-action@v10
       if: ${{ matrix.cachixName != '<YOUR_CACHIX_NAME>' }}
       with:
         name: ${{ matrix.cachixName }}


### PR DESCRIPTION
- GitHub Actions: channel nixos-20.03 -> nixos-20.09
- Bump cachix/cachix-action from v8 to v9
- Bump cachix/install-nix-action from v12 to v13
- Bump cachix/cachix-action from v9 to v10
