### PR TITLE
python3Packages.retworkx: 0.9.0 -> 0.10.2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,6 +62,10 @@ jobs:
           --drv-path --show-trace \
           -I nixpkgs=$(nix-instantiate --find-file nixpkgs) \
           -I $PWD
+    - name: Find Unbroken Nix Packages
+      run: |
+        nix-shell update-shell.nix --run "nix-eval-jobs --option restrict-eval true default.nix > evaluations.json"
+        nix-shell update-shell.nix --run "jq '.|select(.error != null)' evaluations.json"
     - name: Build nix packages
       id: build_uncached
       # if this errors, continue to verbose build.

--- a/.gitignore
+++ b/.gitignore
@@ -6,8 +6,9 @@ result-*
 .envrc.local
 /.direnv/
 
-# artifact from auto-update
+# artifact from auto-update/CI
 nurAttrs.json
+evaluations.json
 
 # Nix shell artifact? for CI
 env-vars

--- a/ci.nix
+++ b/ci.nix
@@ -15,7 +15,10 @@ with builtins;
 let
   isReserved = n: n == "lib" || n == "overlays" || n == "modules" || n == "pkgs";
   isDerivation = p: isAttrs p && p ? type && p.type == "derivation";
-  isBuildable = p: !(p.meta.broken or false) && (p.meta.license.free or true) && !(p.meta.isRpiPkg or false);
+  evaluatedPackages = builtins.map builtins.fromJSON (pkgs.lib.splitString "\n" (pkgs.lib.fileContents ./evaluations.json));
+  
+  canEvaluate = p: elem: ( elem ? "attr" && (pkgs.lib.hasInfix p.pname elem.attr) && (! (elem ? "error")));
+  isBuildable = p: any (canEvaluate p) evaluatedPackages;
   isCacheable = p: !(p.preferLocalBuild or false);
   shouldRecurseForDerivations = p: isAttrs p && p.recurseForDerivations or false;
 
@@ -34,7 +37,7 @@ let
 
   outputsOf = p: map (o: p.${o}) p.outputs;
 
-  nurAttrs = import ./default.nix { rawpkgs = pkgs; };
+  nurAttrs = import ./default.nix { inherit pkgs; };
 
   nurPkgs =
     flattenPkgs

--- a/ci.nix
+++ b/ci.nix
@@ -37,7 +37,7 @@ let
 
   outputsOf = p: map (o: p.${o}) p.outputs;
 
-  nurAttrs = import ./default.nix { inherit pkgs; };
+  nurAttrs = import ./default.nix { };
 
   nurPkgs =
     flattenPkgs

--- a/default.nix
+++ b/default.nix
@@ -6,16 +6,15 @@
 # commands such as:
 #     nix-build -A mypackage
 
-{ rawpkgs ? import <nixpkgs> { } }:
+{ overlays ? import ./overlays
+, pkgs ? import <nixpkgs> { overlays = (builtins.attrValues overlays); }
+}:
 
 rec {
   # The `lib`, `modules`, and `overlay` names are special
   lib = import ./lib { inherit pkgs; }; # functions
   modules = import ./modules; # NixOS modules
-  overlays = import ./overlays; # nixpkgs overlays
-
-  # NOTE: default pkgs to updated versions as required by packages
-  pkgs = rawpkgs.appendOverlays [ overlays.python-updates overlays.library-updates ];
+  inherit overlays; # nixpkgs overlays
 
   # Packages/updates accepted to nixpkgs/master, but need the update
   lib-scs = pkgs.callPackage ./pkgs/libraries/scs { };

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -10,5 +10,17 @@
         "type": "tarball",
         "url": "https://github.com/nmattia/niv/archive/ba57d5a29b4e0f2085917010380ef3ddc3cf380f.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
+    },
+    "nix-eval-jobs": {
+        "branch": "main",
+        "description": "Eval nix expressions from flakes (extracted from hydra) [maintainers @Mic92, @adisbladis]",
+        "homepage": "",
+        "owner": "nix-community",
+        "repo": "nix-eval-jobs",
+        "rev": "2a382fe9f57cd8884001c14e48145cca0fb807fb",
+        "sha256": "1nf8vxr3r66is487wz7hnmpr9gq99va2g6yylbkf9j2rfjmz7gdk",
+        "type": "tarball",
+        "url": "https://github.com/nix-community/nix-eval-jobs/archive/2a382fe9f57cd8884001c14e48145cca0fb807fb.tar.gz",
+        "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }

--- a/pkgs/python-modules/cirq/default.nix
+++ b/pkgs/python-modules/cirq/default.nix
@@ -130,7 +130,9 @@ let
   cirq-google = cirqSubPackage {
     pname = "cirq-google";
     postPatch = ''
-      substituteInPlace requirements.txt --replace "protobuf~=3.13.0" "protobuf"
+      substituteInPlace requirements.txt \
+        --replace "protobuf~=3.13.0" "protobuf" \
+        --replace "google-api-core[grpc] >= 1.14.0, < 2.0.0dev" "google-api-core[grpc] >= 1.14.0, < 3.0.0dev"
     '';
 
     propagatedBuildInputs = [

--- a/pkgs/python-modules/qiskit-optimization/default.nix
+++ b/pkgs/python-modules/qiskit-optimization/default.nix
@@ -29,6 +29,10 @@ buildPythonPackage rec {
     sha256 = "sha256-MsCTMO2wP7CTCh70BG36h5vuMUm0wm4m7XIKnHWEFqo=";
   };
 
+  postPatch = ''
+    substituteInPlace requirements.txt --replace "networkx>=2.2,<2.6" "networkx"
+  '';
+
   propagatedBuildInputs = [
     docplex
     decorator

--- a/pkgs/python-modules/retworkx/default.nix
+++ b/pkgs/python-modules/retworkx/default.nix
@@ -20,14 +20,14 @@
 
 let
   pname = "retworkx";
-  version = "0.9.0";
+  version = "0.10.2";
   src = fetchFromGitHub {
     owner = "Qiskit";
     repo = "retworkx";
     rev = version;
-    sha256 = "0adb9zar8wihjkywal13b6w21hf5z9fh168wnc7j045y2ixw6vnm";
+    sha256 = "sha256-F2hcVUsuHcNfsg3rXYt/erc0zB6W7GdepVOReP3u4lg=";
   };
-  cargoSha256 = "09zmp4zf3r3b7ffgasshr21db7blkwn7wkibka9cbh61593845dh";
+  cargoSha256 = "1ajzxwx0rrzzq844sbv986h4yg6krzhfagc0q6px3sbhnkm9s2i3";
   buildInputs = lib.optionals stdenv.isDarwin [ libiconv ];
   installCheckInputs = [
     pytestCheckHook

--- a/pkgs/python-modules/retworkx/default.nix
+++ b/pkgs/python-modules/retworkx/default.nix
@@ -51,6 +51,7 @@ let
     changelog = "https://github.com/Qiskit/retworkx/releases/tag/${version}";
     license = licenses.asl20;
     maintainers = with maintainers; [ drewrisinger ];
+    broken = versionOlder lib.version "21.05";  # TODO: enable build on 20.09. Broken due to cargo resolving on older cargo version, might work with a Cargo.toml patch?
   };
 
   pre2105Package = rustPlatform.buildRustPackage rec {

--- a/update-shell.nix
+++ b/update-shell.nix
@@ -1,9 +1,11 @@
 { pkgs ? import <nixpkgs> { }
+, sources ? import ./nix/sources.nix { }
 }:
 
 pkgs.mkShell {
   buildInputs = [
     pkgs.nix-update
     pkgs.jq
+    (pkgs.callPackage sources.nix-eval-jobs { })
   ];
 }


### PR DESCRIPTION
- python3Packages.retworkx: 0.9.0 -> 0.10.1

Temporarily disables retworkx for nixos-20.09 due to issues with cargo version compatibility (which causes the cargo dependencies not to be determined/fetched properly). Might try to resolve that later, or just bypass nixos-20.09.

Disabling on nixos-20.09 required a better evaluation check to see if the packages are buildable. Most of the commits in this are addressing that issue.