### PR TITLE
pytest-profiling: add temporary graphviz dependency

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -53,7 +53,7 @@ rec {
       propagatedBuildInputs = oldAttrs.propagatedBuildInputs ++ [ cirq ];
     });
     pytest-plt = pkgs.python3.pkgs.callPackage ./pkgs/python-modules/pytest-plt { };
-    pytest-profiling = pkgs.python3.pkgs.callPackage ./pkgs/python-modules/pytest-profiling { };
+    pytest-profiling = pkgs.python3.pkgs.callPackage ./pkgs/python-modules/pytest-profiling { graphviz = pkgs.graphviz; };
     pubchempy = pkgs.python3.pkgs.callPackage ./pkgs/python-modules/pubchempy { };
     python-box = pkgs.python3.pkgs.callPackage ./pkgs/python-modules/python-box { };
     qutip = pkgs.python3.pkgs.callPackage ./pkgs/python-modules/qutip { };  # removed from nixpkgs b/c it was broken (presumably unused)

--- a/pkgs/python-modules/pytest-profiling/default.nix
+++ b/pkgs/python-modules/pytest-profiling/default.nix
@@ -2,6 +2,7 @@
 , buildPythonPackage
 , fetchPypi
 , gprof2dot
+, graphviz  # TODO: remove once https://github.com/NixOS/nixpkgs/pull/143220 gets to stable branch
 , pytest
 , setuptools-git
   # Check Inputs
@@ -22,6 +23,7 @@ buildPythonPackage rec {
   propagatedBuildInputs = [
     gprof2dot
     pytest
+    graphviz
   ];
 
   checkInputs = [ pytestCheckHook pytest-virtualenv ];


### PR DESCRIPTION
Fixes issue where graphviz/dot was not actually on the path for
pytest-profiling to find.
Fixed in https://github.com/NixOS/nixpkgs/pull/143220.
Should be reverted once https://github.com/NixOS/nixpkgs/pull/143220
is on stable branches.
