### PR TITLE
treewide: remove dontUseSetuptoolsCheck

### DIFF
--- a/pkgs/python-modules/asteval/default.nix
+++ b/pkgs/python-modules/asteval/default.nix
@@ -29,7 +29,6 @@ buildPythonPackage rec {
   '';
 
   pythonImportsCheck = [ "asteval" ];
-  dontUseSetuptoolsCheck = true;
   checkInputs = [ pytestCheckHook ];
 
   meta = with lib; {

--- a/pkgs/python-modules/autoray/default.nix
+++ b/pkgs/python-modules/autoray/default.nix
@@ -25,7 +25,6 @@ buildPythonPackage rec {
     numpy
   ];
 
-  dontUseSetuptoolsCheck = true;
   checkInputs = [ pytestCheckHook pytestcov ];
 
   meta = with lib; {

--- a/pkgs/python-modules/cirq/default.nix
+++ b/pkgs/python-modules/cirq/default.nix
@@ -53,8 +53,7 @@ let
 
     propagatedBuildInputs = if pname != "cirq-core" then ((args.propagatedBuildInputs or [ ]) ++ [ cirq-core ]) else args.propagatedBuildInputs;
 
-    dontUseSetuptoolsCheck = true;
-    checkInputs = args.checkInputs or [ pytestCheckHook ];
+      checkInputs = args.checkInputs or [ pytestCheckHook ];
     # pythonImportsCheck = args.pythonImportsCheck or [ (builtins.replaceStrings [ "-" ] [ "_" ] pname) ];
     meta = args.meta or cirq-core.meta;
   }
@@ -212,8 +211,7 @@ let
       cirq-web
     ];
 
-    dontUseSetuptoolsCheck = true;
-    checkInputs = [ pytestCheckHook ];
+      checkInputs = [ pytestCheckHook ];
     pytestFlagsArray = [
       "--ignore=dev_tools"
     ];

--- a/pkgs/python-modules/cvxpy/default.nix
+++ b/pkgs/python-modules/cvxpy/default.nix
@@ -41,7 +41,6 @@ buildPythonPackage rec {
   '';
 
   checkInputs = [ pytestCheckHook ];
-  dontUseSetuptoolsCheck = true;
   pytestFlagsArray = [ "./cvxpy" ];
   # Disable the slowest benchmarking tests, cuts test time in half
   disabledTests = [

--- a/pkgs/python-modules/numdifftools/default.nix
+++ b/pkgs/python-modules/numdifftools/default.nix
@@ -37,7 +37,6 @@ buildPythonPackage rec {
 
   doCheck = false;
   pythonImportsCheck = [ "numdifftools" ];
-  dontUseSetuptoolsCheck = true;
   checkInputs = [
     pytestCheckHook
     hypothesis

--- a/pkgs/python-modules/oitg/default.nix
+++ b/pkgs/python-modules/oitg/default.nix
@@ -31,7 +31,6 @@ buildPythonPackage {
   pythonCheckImports = [ "oitg" "oitg.fit" ];
 
   checkInputs = [ pytestCheckHook ];
-  dontUseSetuptoolsCheck = true;
 
   # Remove tests from $out directory to avoid conflicts.
   postCheck = ''

--- a/pkgs/python-modules/olsq/default.nix
+++ b/pkgs/python-modules/olsq/default.nix
@@ -42,7 +42,6 @@ buildPythonPackage rec {
     pytestCheckHook
     qiskit-ibmq-provider
   ];
-  dontUseSetuptoolsCheck = true;
 
   pythonImportsCheck = [ "olsq" ];
 

--- a/pkgs/python-modules/openfermion/default.nix
+++ b/pkgs/python-modules/openfermion/default.nix
@@ -46,7 +46,6 @@ buildPythonPackage rec {
   ];
 
   # pythonImportsCheck = [ "openfermion" ]; # has troubles with cirq's import mechanism
-  dontUseSetuptoolsCheck = true;
   checkInputs = [ pytestCheckHook nbformat ];
 
   pytestFlagsArray = [

--- a/pkgs/python-modules/osqp/default.nix
+++ b/pkgs/python-modules/osqp/default.nix
@@ -36,7 +36,6 @@ buildPythonPackage rec {
 
   checkInputs = [ pytestCheckHook cvxopt ];
   pythonImportsCheck = [ "osqp" ];
-  dontUseSetuptoolsCheck = true;  # running setup.py fails if false
   disabledTests = [
     # Disabled b/c mkl support not enabled
     "mkl_"

--- a/pkgs/python-modules/pubchempy/default.nix
+++ b/pkgs/python-modules/pubchempy/default.nix
@@ -19,7 +19,6 @@ buildPythonPackage rec {
   doCheck = false;  # ALL tests require network access
 
   pythonImportsCheck = [ "pubchempy" ];
-  dontUseSetuptoolsCheck = true;
   checkInputs = [ pytestCheckHook ];
 
   meta = with lib; {

--- a/pkgs/python-modules/pygsti/default.nix
+++ b/pkgs/python-modules/pygsti/default.nix
@@ -97,7 +97,6 @@ buildPythonPackage rec {
   ];
 
   checkInputs = [ pytestCheckHook cvxpy nose ];
-  dontUseSetuptoolsCheck = true;
 
   # Run tests from temp directory to avoid nose finding un-cythonized code
   preCheck = ''

--- a/pkgs/python-modules/pyquil/default.nix
+++ b/pkgs/python-modules/pyquil/default.nix
@@ -56,7 +56,6 @@ buildPythonPackage rec {
   ] ++ (lib.optionals (pythonOlder "3.8") [ importlib-metadata ]);
 
   doCheck = false; # tests are complex, seem to depend on certain processes/servers run in docker container.
-  dontUseSetuptoolsCheck = true;
   checkInputs = [
     pytestCheckHook
     ipython

--- a/pkgs/python-modules/pytest-profiling/default.nix
+++ b/pkgs/python-modules/pytest-profiling/default.nix
@@ -27,7 +27,6 @@ buildPythonPackage rec {
   ];
 
   checkInputs = [ pytestCheckHook pytest-virtualenv ];
-  dontUseSetuptoolsCheck = true;
   pytestFlagsArray = [
     "--ignore=tests/integration/test_profile_integration.py"  # fails, virtualenv isn't working
   ];

--- a/pkgs/python-modules/python-box/default.nix
+++ b/pkgs/python-modules/python-box/default.nix
@@ -28,7 +28,6 @@ buildPythonPackage rec {
     toml
   ];
 
-  dontUseSetuptoolsCheck = true;
   checkInputs = [ pytestCheckHook ];
 
   meta = with lib; {

--- a/pkgs/python-modules/pyvisa/default.nix
+++ b/pkgs/python-modules/pyvisa/default.nix
@@ -24,7 +24,6 @@ buildPythonPackage rec {
   propagatedBuildInputs = [ typing-extensions ];
 
   checkInputs = [ pytestCheckHook ];
-  dontUseSetuptoolsCheck = true;
   preCheck = ''
     export PATH=$out/bin:$PATH
   '';

--- a/pkgs/python-modules/qcs-api-client/default.nix
+++ b/pkgs/python-modules/qcs-api-client/default.nix
@@ -51,7 +51,6 @@ buildPythonPackage rec {
   ];
 
   doCheck = false;  # no tests included
-  dontUseSetuptoolsCheck = true;
   # checkInputs = [ pytestCheckHook ];
   pythonImportsCheck = [ "qcs_api_client" ];
 

--- a/pkgs/python-modules/qdldl/default.nix
+++ b/pkgs/python-modules/qdldl/default.nix
@@ -33,7 +33,6 @@ buildPythonPackage rec {
   pythonImportsCheck = [ "qdldl" ];
 
   checkInputs = [ pytestCheckHook ];
-  dontUseSetuptoolsCheck = true;
 
   meta = with lib; {
     description = "A free LDL factorization routine";

--- a/pkgs/python-modules/qiskit-aer/default.nix
+++ b/pkgs/python-modules/qiskit-aer/default.nix
@@ -120,7 +120,6 @@ buildPythonPackage rec {
     setuptools  # temporary workaround for pbr missing setuptools, see https://github.com/NixOS/nixpkgs/pull/132614
     testtools
   ];
-  dontUseSetuptoolsCheck = true;  # Otherwise runs tests twice
 
   preCheck = ''
     # Tests include a compiled "circuit" which is auto-built in $HOME

--- a/pkgs/python-modules/qiskit-aqua/default.nix
+++ b/pkgs/python-modules/qiskit-aqua/default.nix
@@ -103,7 +103,6 @@ buildPythonPackage rec {
     ddt
     qiskit-aer
   ];
-  dontUseSetuptoolsCheck = true;
   pythonImportsCheck = [
     "qiskit.aqua"
     "qiskit.aqua.algorithms"

--- a/pkgs/python-modules/qiskit-finance/default.nix
+++ b/pkgs/python-modules/qiskit-finance/default.nix
@@ -52,7 +52,6 @@ buildPythonPackage rec {
     ddt
     qiskit-aer
   ];
-  dontUseSetuptoolsCheck = true;
 
   pythonImportsCheck = [ "qiskit_finance" ];
   disabledTests = [

--- a/pkgs/python-modules/qiskit-ibmq-provider/default.nix
+++ b/pkgs/python-modules/qiskit-ibmq-provider/default.nix
@@ -76,7 +76,6 @@ buildPythonPackage rec {
     vcrpy
     websockets
   ] ++ lib.optionals (!withVisualization) visualizationPackages;
-  dontUseSetuptoolsCheck = true;
 
   pythonImportsCheck = [ "qiskit.providers.ibmq" ];
   # These disabled tests require internet connection, aren't skipped elsewhere

--- a/pkgs/python-modules/qiskit-ignis/default.nix
+++ b/pkgs/python-modules/qiskit-ignis/default.nix
@@ -36,7 +36,6 @@ buildPythonPackage rec {
 
   # Tests
   pythonImportsCheck = [ "qiskit.ignis" ];
-  dontUseSetuptoolsCheck = true;
   preCheck = ''
     export HOME=$TMPDIR
     pushd $TMP/$sourceRoot

--- a/pkgs/python-modules/qiskit-machine-learning/default.nix
+++ b/pkgs/python-modules/qiskit-machine-learning/default.nix
@@ -50,7 +50,6 @@ buildPythonPackage rec {
     ddt
     qiskit-aer
   ];
-  dontUseSetuptoolsCheck = true;
 
   pythonImportsCheck = [ "qiskit_machine_learning" ];
 

--- a/pkgs/python-modules/qiskit-metal/default.nix
+++ b/pkgs/python-modules/qiskit-metal/default.nix
@@ -63,7 +63,6 @@ buildPythonPackage rec {
   ];
 
   checkInputs = [ pytestCheckHook ];
-  dontUseSetuptoolsCheck = true;
 
   pythonImportsCheck = [
     "qiskit_metal"

--- a/pkgs/python-modules/qiskit-nature/default.nix
+++ b/pkgs/python-modules/qiskit-nature/default.nix
@@ -50,7 +50,6 @@ buildPythonPackage rec {
     ddt
     pylatexenc
   ];
-  dontUseSetuptoolsCheck = true;
 
   pythonImportsCheck = [ "qiskit_nature" ];
 

--- a/pkgs/python-modules/qiskit-ode/default.nix
+++ b/pkgs/python-modules/qiskit-ode/default.nix
@@ -33,7 +33,6 @@ buildPythonPackage rec {
   ];
 
   checkInputs = [ pytestCheckHook ];
-  dontUseSetuptoolsCheck = true;
 
   pythonImportsCheck = [ "qiskit_ode" ];
 

--- a/pkgs/python-modules/qiskit-optimization/default.nix
+++ b/pkgs/python-modules/qiskit-optimization/default.nix
@@ -48,7 +48,6 @@ buildPythonPackage rec {
     pylatexenc
     qiskit-aer
   ];
-  dontUseSetuptoolsCheck = true;
 
   pythonImportsCheck = [ "qiskit_optimization" ];
   pytestFlagsArray = [ "--durations=10" ];

--- a/pkgs/python-modules/qiskit-terra/default.nix
+++ b/pkgs/python-modules/qiskit-terra/default.nix
@@ -97,7 +97,6 @@ buildPythonPackage rec {
     nbconvert
     pytest_xdist
   ] ++ lib.optionals (!withVisualization) visualizationPackages;
-  dontUseSetuptoolsCheck = true;  # can't find setup.py, so fails. tested by pytest
 
   pythonImportsCheck = [
     "qiskit"

--- a/pkgs/python-modules/qiskit/default.nix
+++ b/pkgs/python-modules/qiskit/default.nix
@@ -49,7 +49,6 @@ buildPythonPackage rec {
   ] ++ lib.optionals withOptionalPackages optionalQiskitPackages;
 
   checkInputs = [ pytestCheckHook ];
-  dontUseSetuptoolsCheck = true;
 
   pythonImportsCheck = [
     "qiskit"

--- a/pkgs/python-modules/quimb/default.nix
+++ b/pkgs/python-modules/quimb/default.nix
@@ -43,7 +43,6 @@ buildPythonPackage rec {
     versioneer
   ];
 
-  dontUseSetuptoolsCheck = true;
   preCheck = ''
     substituteInPlace setup.cfg --replace "--cov=quimb --cov-report term-missing" ""
   '';

--- a/pkgs/python-modules/qutip/default.nix
+++ b/pkgs/python-modules/qutip/default.nix
@@ -37,7 +37,6 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "qutip" ];
   checkInputs = [ pytestCheckHook ipython ];
-  dontUseSetuptoolsCheck = true;
   # copy qutip tests to a separate directory so pytest doesn't add $builddir/qutip to PATH,
   # which fails b/c the compiled libraries are missing
   preCheck = ''

--- a/pkgs/python-modules/rpcq/default.nix
+++ b/pkgs/python-modules/rpcq/default.nix
@@ -37,7 +37,6 @@ buildPythonPackage rec {
     substituteInPlace setup.py --replace "msgpack>=0.6,<1.0" "msgpack"
   '';
 
-  dontUseSetuptoolsCheck = true;
   checkInputs = [
     pytestCheckHook
     numpy

--- a/pkgs/python-modules/tuna/default.nix
+++ b/pkgs/python-modules/tuna/default.nix
@@ -21,7 +21,6 @@ buildPythonApplication rec {
     sha256 = "sha256-ilwZCIFM1k9o0mrB/DSlMaawtYR75mEjSfj0f2hjkxo=";
   };
 
-  dontUseSetuptoolsCheck = true;
   checkInputs = [ pytestCheckHook ];
   preCheck = "export PATH=$out/bin:$PATH";
 

--- a/pkgs/python-modules/websocket-client/default.nix
+++ b/pkgs/python-modules/websocket-client/default.nix
@@ -17,7 +17,6 @@ buildPythonPackage rec {
   };
 
   checkInputs = [ pytestCheckHook pysocks ];
-  dontUseSetuptoolsCheck = true;
 
   pythonImportsCheck = [ "websocket" ];
 

--- a/pkgs/raspberrypi/gpiozero/default.nix
+++ b/pkgs/raspberrypi/gpiozero/default.nix
@@ -27,7 +27,6 @@ buildPythonPackage rec {
 
   checkInputs = [ pytestCheckHook mock ];
   pythonImportsCheck = [ "gpiozero" ];
-  dontUseSetuptoolsCheck = true;
 
   meta = with lib; {
     description = "A simple interface to GPIO devices with Raspberry Pi";


### PR DESCRIPTION
Deprecated now that the functionality is auto-set by pytestCheckHook
