### PR TITLE
python3Packages.qiskit-terra: distribute tests

### DIFF
--- a/pkgs/python-modules/qiskit-terra/default.nix
+++ b/pkgs/python-modules/qiskit-terra/default.nix
@@ -112,6 +112,7 @@ buildPythonPackage rec {
     # These tests consistently fail on GitHub Actions build
     "--ignore=test/python/quantum_info/operators/test_random.py"
     "--durations=10"
+    "-n auto"
   ];
   disabledTests = [
     # Flaky tests


### PR DESCRIPTION
Forces tests to run in parallel. Speeds up tests ~2-3 mins?
