### PR TITLE
upstream update

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,9 @@ name: "Build and populate cache"
 on:
   pull_request:
   push:
+    branches:
+      - main
+      - master
   schedule:
     # rebuild everyday at 2:07
     # TIP: Choose a random time here so not all repositories are build at once:
@@ -37,11 +40,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2.3.4
+      uses: actions/checkout@v2.4.0
     - name: Install nix
-      uses: cachix/install-nix-action@v13
+      uses: cachix/install-nix-action@v16
       with:
         nix_path: "${{ matrix.nixPath }}"
+        extra_nix_config: |
+          experimental-features = nix-command flakes
+          access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
     - name: Show nixpkgs version
       run: nix-instantiate --eval -E '(import <nixpkgs> {}).lib.version'
     - name: Setup cachix
@@ -73,7 +79,7 @@ jobs:
         # Allow building unfree packages & unsupported systems for CI purposes
         NIXPKGS_ALLOW_UNFREE: 1
         NIXPKGS_ALLOW_UNSUPPORTED_SYSTEM: 1
-      run: nix run -I 'nixpkgs=channel:nixos-unstable' nixpkgs.nix-build-uncached -c nix-build-uncached ci.nix -A cacheOutputs
+      run: nix shell -f '<nixpkgs>' nix-build-uncached -c nix-build-uncached ci.nix -A cacheOutputs
     # nix-build-uncached uses "nix build" internally, which only outputs last 10 lines of failure.
     # To get more verbose error that we can debug, reruns any failed derivations to get full output
     # Is this nice to the builder? No, but it's better than wasting time guessing at failed builds.


### PR DESCRIPTION
- Bump cachix/install-nix-action from 13 to 14
- ci: fix double workflow trigger on PR
- Bump actions/checkout from 2.3.4 to 2.3.5
- fix build with nixpkgs unstable
- Bump actions/checkout from 2.3.5 to 2.4.0
- Bump cachix/install-nix-action from 14 to 15
- Bump cachix/install-nix-action from 15 to 16
