### PR TITLE
CI: fix package evaluation

### DIFF
--- a/.github/workflows/auto-update.yml
+++ b/.github/workflows/auto-update.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Install nix
       uses: cachix/install-nix-action@v13
       with:
-        nix_path: "nixpkgs=channel:nixos-unstable"
+        nix_path: "nixpkgs=channel:nixos-21.11"
     - name: Show nixpkgs version
       run: nix-instantiate --eval -E '(import <nixpkgs> {}).lib.version'
     - name: Auto-update

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,6 +68,8 @@ jobs:
           -I nixpkgs=$(nix-instantiate --find-file nixpkgs) \
           -I $PWD
     - name: Find Unbroken Nix Packages
+      env:
+        NIX_PATH: channel:nixos-21.11
       run: |
         nix-shell update-shell.nix --run "nix-eval-jobs --option restrict-eval true default.nix > evaluations.json"
         nix-shell update-shell.nix --run "jq '.|select(.error != null)' evaluations.json"

--- a/pkgs/python-modules/cirq/default.nix
+++ b/pkgs/python-modules/cirq/default.nix
@@ -169,6 +169,11 @@ let
         --replace "httpx~=0.15.5" "httpx" \
         --replace "iso8601~=0.1.14" "iso8601" \
         --replace "~=" ">="
+    '' + lib.optionalString (lib.versionAtLeast httpcore.version "0.14.0") ''
+      substituteInPlace cirq_rigetti/service_test.py \
+        --replace "from httpcore._types import URL, Headers" "" \
+        --replace ": URL" "" \
+        --replace ": Headers" ""
     '';
     propagatedBuildInputs = [
       # idna

--- a/pkgs/python-modules/qcs-api-client/default.nix
+++ b/pkgs/python-modules/qcs-api-client/default.nix
@@ -61,6 +61,10 @@ buildPythonPackage rec {
   disabledTests = lib.optionals (lib.versionAtLeast respx.version "0.17.0") [
     "test_sync_client"  # don't seem to work on respx >= 0.17.0
   ];
+  # this file doesn't collect, due to deprecation of respx.MockTransport in v0.18.0
+  disabledTestPaths = lib.optionals (lib.versionAtLeast respx.version "0.18.0") [
+    "tests/test_client/test_client.py"
+  ];
 
   meta = with lib; {
     description = "A client library for accessing the Rigetti QCS API";


### PR DESCRIPTION
- CI (auto-update): pin nixpkgs to nixos-21.11
- CI (build): pin evaluation (nix-eval-jobs) to nixos-21.11

Fixes an issue where evaluation was not succeeding on CI because it was using an incompatible version of nix that nix-eval-jobs expected.

