### PR TITLE
nix: update niv, nix-eval-jobs

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://github.com/nmattia/niv",
         "owner": "nmattia",
         "repo": "niv",
-        "rev": "5830a4dd348d77e39a0f3c4c762ff2663b602d4c",
-        "sha256": "1d3lsrqvci4qz2hwjrcnd8h5vfkg8aypq3sjd4g3izbc8frwz5sm",
+        "rev": "9cb7ef336bb71fd1ca84fc7f2dff15ef4b033f2a",
+        "sha256": "1ajyqr8zka1zlb25jx1v4xys3zqmdy3prbm1vxlid6ah27a8qnzh",
         "type": "tarball",
-        "url": "https://github.com/nmattia/niv/archive/5830a4dd348d77e39a0f3c4c762ff2663b602d4c.tar.gz",
+        "url": "https://github.com/nmattia/niv/archive/9cb7ef336bb71fd1ca84fc7f2dff15ef4b033f2a.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nix-eval-jobs": {
@@ -17,10 +17,10 @@
         "homepage": "",
         "owner": "nix-community",
         "repo": "nix-eval-jobs",
-        "rev": "23523075c2aaaafe9f869d0d35b10d460031c403",
-        "sha256": "1ww1hjqc6042kd4ccfh2wzdpnxqdfp3cnnfkhsm3hz3bmn2sfsxc",
+        "rev": "a08cada21d1c2eb6a49e39da4ad83d0557cb88b2",
+        "sha256": "0x01k6rvx3dnazv9555mmpyyszbd1djpby329f51qsva0kgddjl6",
         "type": "tarball",
-        "url": "https://github.com/nix-community/nix-eval-jobs/archive/23523075c2aaaafe9f869d0d35b10d460031c403.tar.gz",
+        "url": "https://github.com/nix-community/nix-eval-jobs/archive/a08cada21d1c2eb6a49e39da4ad83d0557cb88b2.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }


### PR DESCRIPTION
nix-eval-jobs wasn't compatible with nixpkgs-unstable, should work now.
