### PR TITLE
python3Packages.pyquil: support nixos-unstable

### DIFF
--- a/pkgs/python-modules/pyquil/default.nix
+++ b/pkgs/python-modules/pyquil/default.nix
@@ -3,7 +3,8 @@
 , buildPythonPackage
 , fetchFromGitHub
 , antlr4-python3-runtime
-, lark-parser
+, lark-parser ? null  # <= nixos-21.11
+, lark ? null # > nixos-21.11
 , importlib-metadata
 , networkx
 , numpy
@@ -37,7 +38,7 @@ buildPythonPackage rec {
     # remove numpy hard-pinning, not compatible with nixpkgs 20.09
     substituteInPlace setup.py \
       --replace ",>=1.20.0" "" \
-      --replace "lark==0.*,>=0.11.1" "lark-parser" \
+      --replace "lark==0.*,>=0.11.1" "${if lark != null then "lark" else "lark-parser"}" \
       --replace "scipy==1.*,>=1.6.1" "scipy" \
       --replace "networkx==2.*,>=2.5.0" "networkx" \
       --replace "importlib-metadata==3.*,>=3.7.3" "importlib-metadata"
@@ -45,7 +46,8 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [
     antlr4-python3-runtime
-    lark-parser
+    lark-parser # <= nixos-21.11
+    lark  # > nixos-21.11
     networkx
     numpy
     qcs-api-client
@@ -78,6 +80,6 @@ buildPythonPackage rec {
     homepage = "https://docs.rigetti.com/en/";
     license = licenses.asl20;
     maintainers = with maintainers; [ drewrisinger ];
-    broken = lib.versionOlder lark-parser.version "0.11.1"; # generating parser fails on older versions of Lark parser. Exact version compatibility unknown
+    broken = (lark-parser != null) && (lib.versionOlder lark-parser.version "0.11.1"); # generating parser fails on older versions of Lark parser. Exact version compatibility unknown
   };
 }


### PR DESCRIPTION
In nixpkgs-unstable, I renamed lark-parser -> lark to reflect the
upstream name change.
